### PR TITLE
Updated CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,17 @@
-# Contributing
+## Welcome
+We're glad you're thinking about contributing to an 18F open source project! 
 
-This document provides [18F contributors](https://docs.google.com/spreadsheets/d/1WJIDIMJK2Zzk8bA8DOmqd6Fbfp-tHSbk0-Cv9WPfNlo) (though this document also includes [guidance for non-18F contributors](#non-18F-contributors)) with a high-level picture of the editorial process that will shape their contributions. Over the next six weeks we’ll identify goals for your content, outline the article(s) you'll write in service of those goals, and draft and publish those article(s) as part of the larger guide effort. Easy peasy.
+No one's perfect — especially not us. If you think our guide got something wrong, please let us know. If you're unsure about anything, ask us — or submit the issue or pull request anyway. We love all friendly contributions, and we welcome your ideas about how to keep our UX Guide updated, friendly, and accessible.
 
-If you haven’t seen them yet, please review our [guide goals](https://github.com/18F/ux-guide/wiki/Goals) and [outline](https://github.com/18F/ux-guide/blob/master/README.md#table-of-contents). If you have any questions or concerns, contact us in [#ux-guide](https://gsa-tts.slack.com/archives/CDDLUQ694/) or ping Andrew, Laura, or Vishal. 
+## Adding or changing guidance
 
+Our process for changing the guide is as follows:
 
-## Milestones
+You'll file an issue or submit a pull request asking for a change. (Be sure to let us know why you made the request!). Members of the UX Guide team will discuss the proposed change and comment on your issue. We'll either add the issue to our backlog so that we can prioritize the work required to implement your change or leave you a note explaining why we chose not to.
 
-We recognize that you are balancing working on this alongside billable projects, and want to be respectful of your time. In order to keep us moving forward, we’ve put together some initial milestones (that we’ll adjust as needed). 
+- **Filing an issue.** Please glance through the [existing issues](https://github.com/18f/ux-guide/issues) to see if someone has already raised your issue before filing a new issue using [our feature request or content change template](https://github.com/18F/ux-guide/issues/new?assignees=&labels=&template=feature-request-or-content-change.md&title=).
+- **Submitting a pull request.** Please glance through [our existing pull requests](https://github.com/18f/ux-guide/pulls) to see if we're already working on a similar idea before submitting a new pull request.
 
-- **Goals** by January 9th, 2019
-- **Outlines** by January 18th, 2019
-- **First drafts** by February 1st, 2019
-- **Final drafts** by February 15, 2019
-
-
-## Goals
-
-Kick things off by scheduling a chat with your partner to decide on five goals for your content. 
-
-For example, goals for the “Our approach” section might include (“By reading the ‘our approach’ section of the UX guide, 18F staff will be able to”):
-
-- Conceptualize design as a series of (research and design) decisions that change and articulate a project’s scope — inputs and outputs that help us reach desired outcomes
-- Understand why design requires humility, and how UX designers facilitate feedback loops
-- Describe how 18F’s approach to UX differs on path analysis vs. experiment and iterate engagements
-
-
-## Outlines
-
-Once we’re broadly aligned on content goals, outline the content you’ll write. What will you write to meet your content-related goals? What concepts will you need to introduce, and in what order? 
-
-Break the content into as many articles as you need — where each article is between 500 and 1,500 words (or 1-3 pages). This will ensure that the overall guide is succinct, accessible, and (hopefully) easier to maintain. For example, the “Our approach” section might contain three articles: UX at 18F, Lean UX, and coaching and doing. 
-
-
-## Drafting
-
-Here are some things to keep in mind while writing: 
-
-- The primary audience is 18F staff who are experienced practitioners, so our goal is to capture what’s unique about doing human centered design in our specific context rather than trying to tackle general design-related topics.
-- Use first-person and third-person plural (“I”, “we” and “they”) pronouns, and avoid second person (“you”) altogether as it creates a boundary with the reader.
-- Connect and link to existing 18F content as much as possible. For example, we’re not looking to duplicate the [Methods](https://methods.18f.gov)!
-- Make good use of headings and bullet points. See the [18F content guide](https://content-guide.18f.gov) and [plainlanguage.gov](https://plainlanguage.gov). 
-
-
-## Non-18F contributors
-
-If you do not work at 18F and are interested in making constructive contributions to this guide, you can do that by emailing us, filing an issue, or submitting a pull request. You might also consider forking this guide and customizing it to your organizational needs.
-
-- **Emailing us.** Whether you've got a general question about the guide, or you'd just like to have a conversation outside of GitHub — whatever the reason, feel free to [email us](mailto:18f-research@gsa.gov).
-- **Filing an issue.** See something amiss? Please glance through the [existing issues](https://github.com/18f/ux-guide/issues) to see if someone has already alerted us to your question or concern *before* [filing a new issue](https://github.com/18F/ux-guide/issues/new)!
-- **Submitting a pull request.** Got a better solution in mind? Please glance through [our existing pull requests](https://github.com/18f/ux-guide/pulls) to see if we're already working on a similar idea *before* submitting a pull request.
 
 ## Code of conduct
 To ensure a welcoming environment for our projects, our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md). Contributors should do the same.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ Our process for changing the guide is as follows:
 
 You'll file an issue or submit a pull request asking for a change. (Be sure to let us know why you made the request!). Members of the UX Guide team will discuss the proposed change and comment on your issue. We'll either add the issue to our backlog so that we can prioritize the work required to implement your change or leave you a note explaining why we chose not to.
 
-- **Filing an issue.** Please glance through the [existing issues](https://github.com/18f/ux-guide/issues) to see if someone has already raised your issue before filing a new issue using [our feature request or content change template](https://github.com/18F/ux-guide/issues/new?assignees=&labels=&template=feature-request-or-content-change.md&title=).
-- **Submitting a pull request.** Please glance through [our existing pull requests](https://github.com/18f/ux-guide/pulls) to see if we're already working on a similar idea before submitting a new pull request.
+- **Filing an issue.** See something amiss? Please glance through the [existing issues](https://github.com/18f/ux-guide/issues) to see if someone has already raised your issue before filing a new issue using [our feature request or content change template](https://github.com/18F/ux-guide/issues/new?assignees=&labels=&template=feature-request-or-content-change.md&title=).
+- **Submitting a pull request.** Got a better solution in mind? Please glance through [our existing pull requests](https://github.com/18f/ux-guide/pulls) to see if we're already working on a similar idea before submitting a new pull request.
 
 
 ## Code of conduct


### PR DESCRIPTION
Removed guidance specific to 18F teams, revised instructions, and added link to new issue template.