### PR TITLE
Added separate refs pafe

### DIFF
--- a/_pages/references
+++ b/_pages/references
@@ -1,0 +1,27 @@
+# References
+
+This guide draws on information from the many following resources. GSA cannot This list does not represent an endorsement any of these resources, or their respective authors, by 18F or the General Services Administration. GSA employees interested in further reading can access an internal list of references. 
+
+ - Practical Design Discovery by Dan Brown
+ - How to Make Sense of Any Mess by Abby Covert
+ - IDEO’s Little Book of Design Research Ethics
+ - Just Enough Research by Erika Hall
+ - “Research Questions Are Not Interview Questions” by Erika Hall
+ - "Dig in the Right Spot" by Erika Hall
+ - “The 9 Rules of Design Research” by Erika Hall
+ - Practical Ethnography by Sam Ladner
+ - “Are You Really Prepared for Your Usability Study?” by Christine Perfetti
+ - Interviewing Users by Steve Portigal
+ - The researcher’s journey: leveling up as a user researcher by Dave Hora
+ - Seeing the Elephant: Defragmenting User Research by Lou Rosenfeld
+ - Convivial Toolbox: Generative Research for The Front End of Design by Elizabeth  - Sanders and Pieter Jan Stappers
+ - “Avoiding bias in the oh-so-human world of user testing” by Ashlea McKay
+ - U.S. Office of Personnel Management  (The Lab@OPM) Human-centered design Discovery Stage Operations Guide
+ - U.S. Department of Health and Human Services. The Belmont Report.
+- U.S. Department of Health, Education & Welfare. Records, Computers, and the Rights of Citizens.
+ - U.S. Department of Homeland Security. The Menlo Report: Ethical Principles  Guiding Information and Communication Technology Research.
+ - Context Integrity and Consent in Presenting Research by PJ Patella-Rey
+ - “What is your Riskiest Assumption?” by Neda D Stevanović
+ - The User research section of the Gov.uk Service Manual
+ - “Getting informed consent for user research” | Gov.uk 
+ - “Finding participants for user research” | Gov.uk 


### PR DESCRIPTION
Just a placeholder for links that we'll need to add back in. This page will need to be locked to folks outside of GSA, as making it public could appear like an endorsement.