### PR TITLE
Add development instruction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ This guide is currently under development. It is a living guide that will contin
     1. [Use a design system](https://github.com/18F/ux-guide/blob/master/_pages/design/use-a-design-system.md)
 1. Resources
 
+## Development
+The UX Guide uses [USWDS-Jekyll](https://github.com/18F/uswds-jekyll).
+
+To test it locally:
+
+1. Clone this repo
+2. In the local clone of this repo, run `jekyll serve`
+
+---
 
 ## Contributors
 


### PR DESCRIPTION
_Note_: This is a suggestion to clarify on the README.md. Feel free to reject if it doesn't provide value to the UX Guide team.

---

**Why:** As UX Guide contributor, I want to know how to locally run/test the UX Guide so I can preview changes

**How:** Pulls instruction from USWDS-Jekyll README.md (Not from Federalist-USWDS-Jekyll, which has different steps)
