### PR TITLE
Re-patch side nav / content width inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/69/2fc3412b9ad8f59432faee02329d9f9d7ddfacb8e43858b761db91d6727c79
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/8a/422a8b44f0c8ab242e9af8bdb134dd697333bfbda9429162f5be8de1e86412
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/bc/847d20c51ea6b436a1df0d884e9377556c7289804910eb0c0c32877a92d621
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/b7/86cbc5a369d5863653510706f99b41369083f5f2d468e6ab8401f9272d406e

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/34/959c61a79f551b892a3e0e82cf61421332f003bf83bfda333dd895181d4cb5
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/0c/1029fbaf5d7bfc398fac03d601e836482750298ee98c41bc92cf86da40a420
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/69/2fc3412b9ad8f59432faee02329d9f9d7ddfacb8e43858b761db91d6727c79
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/8a/422a8b44f0c8ab242e9af8bdb134dd697333bfbda9429162f5be8de1e86412
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/bc/847d20c51ea6b436a1df0d884e9377556c7289804910eb0c0c32877a92d621

--- a/_pages/research/legal.md
+++ b/_pages/research/legal.md
@@ -26,12 +26,14 @@ As a general matter, agency funds are not available to provide [incentives](http
 
 
 ### Research methods and modes
+
 In their [Flexibilities under the Paperwork Reduction Act](https://obamawhitehouse.archives.gov/sites/default/files/omb/inforeg/pra_flexibilities_memo_7_22_16_finalI.pdf) memo, OIRA says that (emphasis added) “OMB does not generally consider facts or opinions obtained through **direct observation** by an employee or agent of the sponsoring agency or through **non-standardized oral communications** in connection with such direct observations to be information under the PRA.” 
 
 18F UX designers generally comply with PRA by showing preference for qualitative research methods (such as semi-structured interviews and usability tests) and research modes that involve direct observation. Moreover, [we often find that we reach saturation](https://www.nngroup.com/articles/why-you-only-need-to-test-with-5-users/) before speaking with ten or more people (though note that for structured information collections, a response of any kind counts towards the ten; even “no, thank you”). We work with our partner agency’s PRA desk officer whenever we want to collect structured information from ten or more people.
 
 
 ### Intercepts
+
 18F designs our intercepts with the PRA in mind. Per [this OIRA memo](https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/inforeg/SocialMediaGuidance_04072010.pdf) (specifically “Feedback requests: [...] an agency does not trigger the PRA’s requirements when it posts its email address or uses an application for brainstorming or idea generating on its website to enable the public to submit feedback”), our intercepts don’t require PRA approval so long as they only ask for people’s contact information, such as their name, email address, mailing address, and phone number.
 
 Our intercepts also generally do not ask people to disclose information about themselves as a consequence of their responding. For example, we wouldn’t say “Are you the parent of a 4th grader? We’d love your feedback on everykidinapark.gov,” because this is effectively a structured information collection (since anyone who responds is effectively saying “Yes, I’m the parent of a 4th grader”). To be on the safe side, our intercepts generally target either *everyone* or a *specific individual.*

--- a/_sass/custom/_uswds-theme-custom-styles.scss
+++ b/_sass/custom/_uswds-theme-custom-styles.scss
@@ -138,3 +138,9 @@ a:hover {
 .usa-prose > h6 {
   line-height: 1.5;
 }
+
+// Set property values for code block
+pre {
+  white-space: pre-wrap;
+  max-width: 30em;
+} 

--- a/_sass/custom/_uswds-theme-custom-styles.scss
+++ b/_sass/custom/_uswds-theme-custom-styles.scss
@@ -129,6 +129,11 @@ a:hover {
   max-width: 40em;
 }
 
+// Set max-width to contain long table data text
+.usa-prose > table td {
+  max-width: 25em;
+}
+
 // Set line-height to specify distance between lines of text
 .usa-prose > h1,
 .usa-prose > h2,

--- a/_sass/custom/_uswds-theme-custom-styles.scss
+++ b/_sass/custom/_uswds-theme-custom-styles.scss
@@ -3,7 +3,6 @@
   width: auto;
 }
 
-
 //// 18F styles
 
 // Color
@@ -23,7 +22,6 @@ $color-gray-hover:    #fafafa;
 $color-gray-divider:  #bbbbbb;
 
 $color-gray-border:   #5b616b;
-
 
 // Typography
 h1, h2, h3, h4, h5, h6,
@@ -59,7 +57,7 @@ a:hover {
   color: $color-medium-hover;
 }
 
-// header
+// Header
 .usa-nav .usa-current::after,
 .usa-header--extended .usa-current:hover::after,
 .usa-nav__primary>.usa-nav__primary-item > .usa-current:hover::after {
@@ -79,8 +77,6 @@ a:hover {
 .usa-nav__primary>.usa-nav__primary-item > a:hover::after {
   height: 0;
 }
-
-
 
 // usa-sidenav
 
@@ -107,4 +103,28 @@ a:hover {
 .usa-sidenav a:hover {
   color: inherit;
   background-color: $color-gray-lightest;
+}
+
+//// Set max-width
+
+// Set max-width to contain long H1 text
+.usa-prose > h1 {
+  max-width: 17em;
+}
+
+// Set max-width to contain long H2 text
+.usa-prose > h2 {
+  max-width: 19.5em;
+}
+
+// Set max-width to contain long H3 text
+.usa-prose > h3 {
+  max-width: 30em;
+}
+
+// Set max-width to contain long H4-H6 text
+.usa-prose > h4, 
+.usa-prose > h5,
+.usa-prose > h6 {
+  max-width: 40em;
 }

--- a/_sass/custom/_uswds-theme-custom-styles.scss
+++ b/_sass/custom/_uswds-theme-custom-styles.scss
@@ -105,7 +105,7 @@ a:hover {
   background-color: $color-gray-lightest;
 }
 
-//// Set max-width
+//// Customization
 
 // Set max-width to contain long H1 text
 .usa-prose > h1 {
@@ -127,4 +127,14 @@ a:hover {
 .usa-prose > h5,
 .usa-prose > h6 {
   max-width: 40em;
+}
+
+// Set line-height to specify distance between lines of text
+.usa-prose > h1,
+.usa-prose > h2,
+.usa-prose > h3,
+.usa-prose > h4,
+.usa-prose > h5,
+.usa-prose > h6 {
+  line-height: 1.5;
 }


### PR DESCRIPTION
**Why:** This PR addresses issue #161 (More context in it)

**How:**
- Clean up CSS and set `max-width` for H1-H6 headings
- Set `line-height` to specify distance between lines of text
- Set property values for `code` block
- Set `max-width` to contain long table data text
- Clean up `legal.md` format - Does not affect content 

[Preview via Federalist](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/nng-repatch-side-nav-content-width/)

**Note:** When reviewed and merged, close #161.