### PR TITLE
Add H2 headings to subnavs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/87/3a97ef3e57383e5498da719b6103f4e04927b0014548a1859de516adcb2d5d
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/f7/707bfd9cc36e9008848a7d7553d40ac7fe036d5dfc50a1f6cd174030fd15b6
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/bf/30262f624ae0232fc601bbc478871a6d0670ac05c6ac495be9ae9b9462bf9c
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/4d/1146497fc902d46c24855dc2707a4b31c9f3ee20eb136bb476f26d26435b42
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/66/0c2d58865417b9a79ce84d7a34afad6060b233e9d99756ccd1b1765291be05
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/6b/ce8bcc146c6c6976820bd8cb7aafafe3e4e2568aa192eaf4b4c09254a6edde

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/e3/0cb829209571f8aace575a5af6de7590fc9d550eb7843bb735b9814ae7bc58
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/dd/410602dfc6989e31ac2f7ce07cd284d3e4e03dad19165334eeca4e28d97f33
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/6c/5feda65a7a048ed97813a7d34805119a406cac5e6dbe7719e8f5ac0d980103
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/8b/d0d6636864c39152f34aaba777387c65f955dc46ce46bd7d2acda21c68f736

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/84/0aebfabf53e122ee50a87cc4a329c6ac9cac39869cc18b0a7f7e68d10bc856
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/87/3a97ef3e57383e5498da719b6103f4e04927b0014548a1859de516adcb2d5d
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/f7/707bfd9cc36e9008848a7d7553d40ac7fe036d5dfc50a1f6cd174030fd15b6
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/bf/30262f624ae0232fc601bbc478871a6d0670ac05c6ac495be9ae9b9462bf9c

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/4d/1146497fc902d46c24855dc2707a4b31c9f3ee20eb136bb476f26d26435b42
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/66/0c2d58865417b9a79ce84d7a34afad6060b233e9d99756ccd1b1765291be05
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/6b/ce8bcc146c6c6976820bd8cb7aafafe3e4e2568aa192eaf4b4c09254a6edde
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/e3/0cb829209571f8aace575a5af6de7590fc9d550eb7843bb735b9814ae7bc58
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/dd/410602dfc6989e31ac2f7ce07cd284d3e4e03dad19165334eeca4e28d97f33
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/6c/5feda65a7a048ed97813a7d34805119a406cac5e6dbe7719e8f5ac0d980103

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/56/d3d98d77790894fe56090a507739954c36d391daff3e0812a30a0b18d876a9
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/fb/c633ee9a78c40df34efa453683670ceb5ec8539c7b8cf5121c8bd528f5dcee
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/d1/ac2f276845518c988af10f1aae274c0cece78941a873f65061bb8c2ee47ff7
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/a9/a9d5962a596633aebcc4f5c480540a3ac6c3156086f38b344844620145e731

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/8b/d0d6636864c39152f34aaba777387c65f955dc46ce46bd7d2acda21c68f736
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/56/d3d98d77790894fe56090a507739954c36d391daff3e0812a30a0b18d876a9
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/fb/c633ee9a78c40df34efa453683670ceb5ec8539c7b8cf5121c8bd528f5dcee
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/d1/ac2f276845518c988af10f1aae274c0cece78941a873f65061bb8c2ee47ff7

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/dd/410602dfc6989e31ac2f7ce07cd284d3e4e03dad19165334eeca4e28d97f33
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/6c/5feda65a7a048ed97813a7d34805119a406cac5e6dbe7719e8f5ac0d980103
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/8b/d0d6636864c39152f34aaba777387c65f955dc46ce46bd7d2acda21c68f736
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/56/d3d98d77790894fe56090a507739954c36d391daff3e0812a30a0b18d876a9
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/fb/c633ee9a78c40df34efa453683670ceb5ec8539c7b8cf5121c8bd528f5dcee

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/e3/b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/3a/cc79c9ef32011137c6bac2c8cb4d10500085dae4a345d6c8aa43db58a17b35
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/03/d04d653fc83c32f35a23bb6841676842a0c15e84102229d23027a67b09d6f5
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/15/ffaf90f9a1eaa8ec6f75aec4bf3ce5f7266d98ae34e146e4f04cc30237c2ee
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/37/e862c1dfeca58038772e5d161771f1f3d7e2b66fe0a7cad3b9355a6f19ecb4
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/67/3d8024098793ea4229a7ab941d7ecf94ead71e1c5f9f075f2ecb9943c1a928
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/84/0aebfabf53e122ee50a87cc4a329c6ac9cac39869cc18b0a7f7e68d10bc856
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/87/3a97ef3e57383e5498da719b6103f4e04927b0014548a1859de516adcb2d5d
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/f7/707bfd9cc36e9008848a7d7553d40ac7fe036d5dfc50a1f6cd174030fd15b6

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ _site
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/2d/ddf7222257939fc98e961d1041a52e8e50ef5991853f450ee888d8ad7487fa
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/63/b1b8c88f7e558987a96a3c0fb269b668427e03c771d138a8d8887a92dc1d2f
 .jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/74/927a107f803fe20ba19a7cbc6f8458f62f03bb433520b1498a94e6619a7897
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/e3/b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/3a/cc79c9ef32011137c6bac2c8cb4d10500085dae4a345d6c8aa43db58a17b35
+.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/03/d04d653fc83c32f35a23bb6841676842a0c15e84102229d23027a67b09d6f5

--- a/.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/28/626f23238d0d574696c1392767d5e02ad3c1f6773c2a684497c401a56c86c0
+++ b/.jekyll-cache/Jekyll/Cache/Jekyll--Converters--Markdown/28/626f23238d0d574696c1392767d5e02ad3c1f6773c2a684497c401a56c86c0
@@ -1,0 +1,61 @@
+I"�<p>Prototypes are useful to inform a new concept, identify how to refactor an existing product feature, service, or process, and help uncover current development unknowns.</p>
+
+<p>Use prototypes to:</p>
+
+<ul>
+  <li>Align the team (“What problem are we solving?”)</li>
+  <li>Further specify elements of the design (“Should it look like this, or that?”)</li>
+  <li>Demonstrate that your ideas are technically possible</li>
+  <li>Explore/set up the deployment process</li>
+  <li>Demonstrate a collaborative design process</li>
+  <li>Reduce risk</li>
+  <li>Validate a <a href="https://methods.18f.gov/decide/design-hypothesis/">design hypothesis</a></li>
+</ul>
+
+<p>Prototypes can range in fidelity from basic paper prototypes to fully functional software. The idea is to build something that will help you answer your questions with the least investment. Prototyping can take many different forms depending on what you are trying to do. For example:</p>
+
+<ul>
+  <li>Paper sketches are fast to make and to change, and easy for the whole team to participate in designing</li>
+  <li><a href="https://methods.18f.gov/make/wireframing/">Wireframes</a> are preliminary blueprints that can help teams align on structure, placement, and hierarchy for a product or service</li>
+  <li>Static visual mock-ups can help communicate and test things like brand identity and tone</li>
+  <li>Clickable prototypes can help test usability by finding out if users can complete the needed tasks</li>
+</ul>
+
+<h2 id="communicating-with-prototypes">Communicating with prototypes</h2>
+
+<p><a href="https://methods.18f.gov/make/prototyping/">Prototypes</a> provide realistic depictions of a user experience, so it’s important to carefully consider the elements that go into yours. Prototypes can help you convey several things:</p>
+
+<h3 id="1-elements-of-the-design-system">1. Elements of the design system</h3>
+
+<p><strong>Visually</strong> the prototype can include design patterns, color palettes, and font styles to communicate the general look of the final design system. This provides an opportunity for discussion if anything in the aesthetic style needs to be refined or is missing.</p>
+
+<h3 id="2-information-architecture">2. Information architecture</h3>
+
+<p>The <strong>information</strong> hierarchy gets communicated in the prototype. Global navigation menu, contextual navigation, and content hierarchy and structure are laid out in the prototype. Using real content is important, rather than grabbing placeholders like lorem ipsum, so the product team can determine if the proposed content works in the proposed design layout. Testing assumptions or <a href="https://methods.18f.gov/decide/design-hypothesis/">hypotheses</a> with real content will validate and identify if the content is appropriate and if changes are needed.</p>
+
+<h3 id="3-system-behavior">3. System behavior</h3>
+
+<p>A prototype is a great way to communicate system behavior through interaction design. Adding drop-down menus, transitions, and/or gestures doesn’t just make the prototype slick; depicting interaction behaviors helps engineers assess the work to implement the design and identifies potential blockers. Also, <a href="https://methods.18f.gov/validate/usability-testing/">usability tests</a> will uncover if any of the interactions pose problems for your users or could be served better by a different design.</p>
+
+<h2 id="building-prototypes-with-federalist">Building prototypes with Federalist</h2>
+
+<p><a href="https://federalist.18f.gov/">Federalist</a> is a product built by 18F to help manage and deploy static websites. While many organizations may use Federalist to host and deploy their production code, Federalist is also a great tool for automatically creating and deploying preview versions of websites.</p>
+
+<p>If your project is hosted on Federalist, you may configure the platform to build a custom version of the site for every branch on Github. This makes it easy for designers to make changes in their content and code and see what they would look like as rendered HTML. Federalist is set up to constantly monitor Github for any changes so when you create a new git commit Federalist will start building a new version of the site.</p>
+
+<p>Federalist also provides a number of <a href="https://federalist.18f.gov/pages/using-federalist/templates/">templates</a> you can use to kick start your new project or idea. The templates are built with the <a href="https://designsystem.digital.gov/">U.S. Web Design System</a> so you have a library of additional components at your disposal.</p>
+
+<h2 id="getting-started-with-federalist">Getting started with Federalist</h2>
+
+<p>When you’re ready to get started with Federalist, you’ll want to jump into the #federalist-support room on Slack and ask the team to add your Github account to Federalist. 
+Once they’ve added your account, you can <a href="https://federalistapp.18f.gov/">sign in</a> by authorizing access to your Github account and checking out the <a href="https://federalist.18f.gov/pages/using-federalist/">Using Federalist guide</a>.</p>
+
+<h2 id="authorized-prototyping-tools">Authorized prototyping tools</h2>
+
+<p>Depending where you worked prior to joining 18F, you are probably accustomed to having some flexibility around your design toolset. Working for the government means only using tools that have been granted an <a href="https://before-you-ship.18f.gov/ato/">Authority to Operate (ATO)</a>: due to security compliance, we are only allowed to use GSA IT-approved tools.</p>
+
+<p>Don’t fret! 18F has done a great job of getting us licenses to standard prototyping <a href="https://handbook.18f.gov/design/#tools">tools</a>. To request licenses, <a href="https://handbook.18f.gov/design/#tools">review the 18F Handbook</a>. Ensure you review the usage parameters for each tool.</p>
+
+<p>The team is always exploring other tool options for the 18F toolbox. You can investigate whether someone has already submitted an ATO for a new prototyping tool in the <a href="https://gsa-tts.slack.com/messages/design">#design</a> or <a href="https://gsa-tts.slack.com/messages/ux">#ux</a> slack channels, or you can look it up at <a href="https://handbook.18f.gov/software/#step-1-find-or-get-an-ato">GEAR</a>, the IT standards list.</p>
+
+:ET

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,11 @@ title: License
 permalink: /license/
 sidenav: overview
 sticky_sidenav: true
+subnav:
+  - text: No copyright
+    href: '#no-copyright'
+  - text: Other information
+    href: '#other-information'
 ---
 
 As a work of the federal government, this project is in the public domain within the United States.

--- a/_pages/design/build a prototype.md
+++ b/_pages/design/build a prototype.md
@@ -4,6 +4,15 @@ title: Build a prototype
 permalink: /design/build-a-prototype/
 sidenav: design
 sticky_sidenav: true
+subnav: 
+- text: Communicating with prototypes
+  href: '#communicating-with-prototypes'
+- text: Building prototypes with Federalist 
+  href: '#building-prototypes-with-federalist'
+- text: Getting started with Federalist
+  href: '#getting-started-with-federalist'
+- text: Authorized prototyping tools 
+  href: '#authorized-prototyping-tools'
 ---
 
 Prototypes are useful to inform a new concept, identify how to refactor an existing product feature, service, or process, and help uncover current development unknowns. 
@@ -53,6 +62,7 @@ Federalist also provides a number of [templates](https://federalist.18f.gov/page
 
 
 ## Getting started with Federalist
+
 When you’re ready to get started with Federalist, you’ll want to jump into the #federalist-support room on Slack and ask the team to add your Github account to Federalist. 
 Once they’ve added your account, you can [sign in](https://federalistapp.18f.gov/) by authorizing access to your Github account and checking out the [Using Federalist guide](https://federalist.18f.gov/pages/using-federalist/).
 

--- a/_pages/design/use a design system.md
+++ b/_pages/design/use a design system.md
@@ -4,11 +4,16 @@ title: Use a design system
 permalink: /design/use-a-design-system/
 sidenav: design
 sticky_sidenav: true
+subnav:
+  - text: The U.S. Web Design System
+    href: '#the-us-web-design-system'
 ---
 
 A design system can help your team prototype faster, scale, manage front-end design debt, and apply consistency across your applications. As a project grows, designers and engineers often find themselves managing dozens of variations of the same button, for example, across hundreds of lines of code. This can create duplication that slows down the build process, requiring extra work to ensure consistent styles across all the appropriate states, and adds more things to check as you’re making sure every screen of your application is accessible to all.
 
+
 ## The U.S. Web Design System
+
 [21st Century IDEA](https://digital.gov/resources/21st-century-integrated-digital-experience-act/) requires agencies to comply with the [website standards](https://designsystem.digital.gov/website-standards/) created by TTS. The website standards say agencies should use the [U.S. Web Design System (USWDS)](https://designsystem.digital.gov). 
 
 Many teams at 18F begin by [installing](https://designsystem.digital.gov/documentation/developers/) the USWDS package and adding additional components and styles to fit the needs of their application. 

--- a/_pages/our-approach/meet-people-where-they-are.md
+++ b/_pages/our-approach/meet-people-where-they-are.md
@@ -4,6 +4,19 @@ title: Meet partners where they are
 permalink: /our-approach/meet-partners-where-they-are/
 sidenav: our-approach
 sticky_sidenav: true
+subnav:
+  - text: Ability to participate
+    href: '#ability-to-participate'
+  - text: Design maturity
+    href: '#design-maturity'
+  - text: Remote friendliness
+    href: '#remote-friendliness'
+  - text: Access to collaboration tools
+    href: '#access-to-collaboration-tools'
+  - text: Security and privacy norms
+    href: '#security-and-privacy-norms'
+  - text: Policy
+    href: '#policy'
 ---
 
 Meeting partners where they are helps encourage a more participatory, and therefore sustainable, design process. 
@@ -71,7 +84,6 @@ Engaging partners in conversations about how they might level-up in their practi
 In general, people who are new to design will need to appreciate its direct benefits (like improved usability and customer adoption) before its indirect benefits (such as helping the team identify the most important problems for them to solve). Because of this, we aim to give your partners something tangible, and. Let them experience the show before pulling back the curtain.
 
 
-
 ## Remote friendliness
 
 18F is a distributed team for many reasons. For example, being distributed allows us to hire people who would not traditionally join government or move to DC, and it allows us to include a broader cross-sampling of people when conducting design research. Being remote-first requires that we maintain [a number of remote-friendly practices](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/).
@@ -88,7 +100,6 @@ Depending on the answers to the above questions we might:
 - Modify activities to facilitate  remote or in-person participation, depending on what the project calls for  (for example, arranging digital sticky notes on a digital whiteboard rather than using real sticky notes).
 
 
-
 ## Access to collaboration tools
 
 18F has fairly unique access (within the US federal government, at least) to web-based collaboration software, including chat, whiteboards, wireframing, and prototyping tools. Our agency partners may not have access to these tools, or may be prohibited from using them they way we do. For example, they may be able to video chat, but may be unable to share their screen. 
@@ -96,7 +107,6 @@ Depending on the answers to the above questions we might:
 We coordinate with partners to identify which combination of tools will work best for our collaboration, often using a mix of communication tools already in use by the partner agency and new tools that 18F can share access to. 
 
 Our collaborations are frequently anchored by at least one or two in-person sessions, where we may use analog tools such as sticky notes, pencil, and paper or conduct in-person research such as observation that can later be documented in a digital form. 
-
 
 
 ## Security and privacy norms
@@ -115,8 +125,8 @@ We also meet our partners where they are by discussing privacy norms and relevan
 - [Paperwork Reduction Act](https://pra.digital.gov/) (PRA) Desk Officer
 
 
-
 ## Policy
+
 Practicing user-centered design in government is complex. In some cases, we can find that policy dictates decisions we otherwise thought were ours to make about how a product or service functions or how we carry out the user-centered design process. For example, as we helped build [the new FEC.gov](https://18f.gsa.gov/2017/05/30/the-new-fec/) 18F conducted usability testing to see how our proposed designs might affect the site’s usability. If we were to suggest changes to the forms that campaigns use to file with the FEC, the FEC might be legally required to solicit public feedback in the Federal Register over a multi-month period.
 
 As we collaboratively design with partners, we should ask:

--- a/_pages/our-approach/stay-lean.md
+++ b/_pages/our-approach/stay-lean.md
@@ -4,6 +4,13 @@ title: Stay lean
 permalink: /our-approach/stay-lean/
 sidenav: our-approach
 sticky_sidenav: true
+subnav:
+  - text: Lean UX at 18F
+    href: '#lean-ux-at-18f'
+  - text: Lean UX Principles
+    href: '#lean-ux-principles'
+  - text: Acknowledgements
+    href: '#acknowledgements'
 ---
 
 18F UX designers take a collaborative, outcome-focused approach to our work. We manage risk through continuous learning. Each new iteration builds on the user-validated research of the previous iteration. 
@@ -88,6 +95,7 @@ In addition to our team principles, the following principles from Lean UX are es
 **Make assumptions explicit.** We write down and discuss the assumptions we have about users and the problems they face as part of our research planning process, and [test the riskiest or most critical assumptions](https://mvpworkshop.co/validate-riskiest-assumption/) as early as possible.
 
 Prioritization. Ruthless and ongoing prioritization is essential to our focus.
+
 
 ## Acknowledgements
 

--- a/_pages/our-approach/values-and-principles.md
+++ b/_pages/our-approach/values-and-principles.md
@@ -4,6 +4,11 @@ title: Values and principles
 permalink: /our-approach/values-and-principles/
 sidenav: our-approach
 sticky_sidenav: true
+subnav:
+- text: We value
+  href: '#we-value'
+- text: Our principles
+  href: '#our-principles'
 ---
 
 We believe that good design helps government better serve the public. 18F UX designers join cross-functional teams to improve interactions between government agencies and the people they serve. Together, we’re helping build a 21st century government that works for all.
@@ -25,21 +30,17 @@ Our approach is fundamentally collaborative. This document exists to help our cr
 
 The following principles guide our team in meeting [18F’s mission](https://18f.gsa.gov/about/#our-mission) of transforming how the U.S. government builds and buys digital services.
 
-
 ### We start with user needs
 
 We always begin with identifying our partners’ needs and the needs of the people they serve. Through a variety of [research methods](https://methods.18f.gov/), we explore how to best meet those needs. We seek first to understand who we are designing for, then figure out how to deliver effective solutions. By starting with user needs, we can work within our partner’s constraints while also working to change those constraints.
-
 
 ### We use an iterative process of learning and discovery informed by data
 
 A flexible vision is critical. We use data and direct conversations with users to inform our decisions. We prototype ideas and do frequent rounds of research to give our teams the evidence to make better decisions. We deliver early and often, using an iterative cycle of build, test, and learn to refine our ideas over time. Quick feedback loops keep the cost of change low and mean little mistakes don’t become big failures.
 
-
 ### We promote inclusion
 
 In government, good design serves everyone within an agency's mandate. To do this, we promote diversity and inclusion throughout our research and design process by accounting for everyone our decisions affect. Having a team with varied life experience—particularly around issues of accessibility and technology usage—helps us create more accessible, usable products and services.
-
 
 ### We design together
 
@@ -47,11 +48,9 @@ We collaborate across disciplines to create a shared understanding of the proble
 
 Working together fosters a sense of trust and shared ownership within the team. Open conversation about works-in-progress promotes real agility. 
 
-
 ### We train advocates
 
 Our partners are experts in their field. Collaborating closely allows us a glimpse into their expertise and them into ours. The shared understanding this work builds allows us to recommend next steps and them to advocate for better design practices to their colleagues. This advocacy for user-centered design lasts long after our partnership ends.
-
 
 ### We finish with user needs
 

--- a/_pages/research/bias.md
+++ b/_pages/research/bias.md
@@ -4,6 +4,21 @@ title: Bias
 permalink: /research/bias/ 
 sidenav: research
 sticky_sidenav: true
+subnav:
+  - text: Research design bias
+    href: '#research-design-bias'
+  - text: Sampling bias
+    href: '#sampling-bias'
+  - text: Interviewer bias
+    href: '#interviewer-bias'
+  - text: Social desirability bias
+    href: '#social-desirability-bias'
+  - text: Confirmation bias
+    href: '#confirmation-bias'
+  - text: The observer effect
+    href: '#the-observer-effect-the-hawthorne-effect'
+  - text: Avoiding bias
+    href: '#avoiding-bias'
 ---
 
 All research is subject to bias, whether in our choice of who participates,  which pieces of information are collected, or how they’re interpreted. Proactively engaging with bias helps us improve the credibility of our research. The following list is our starting point. 

--- a/_pages/research/clarify-the-basics.md
+++ b/_pages/research/clarify-the-basics.md
@@ -21,12 +21,14 @@ subnav:
 
 Design research can feel overwhelming, even to people who’ve done it before! Clarify the basics with your team before you dive in.
 
-# What it is
+
+## What it is
 Design research explores possibilities, tests assumptions, and reduces risk by actively and systematically engaging with the world. It includes qualitative and quantitative methods, investigating tools and systems, and interacting with members of the public.
 
 All 18F teams do design research. [Design involves continuous decision-making](https://drive.google.com/a/gsa.gov/open?id=1WVDQFLEiNFzCuWH9D6hMLTQXaBJWZ-aElXl5qqOjdHg), and those decisions are made better when they’re informed by end user perspectives. As a result, we’re committed to continuous research. Rather than seeing designed products or services themselves as the goal, we view the products or services we’re designing as the result of our continued effort to identify, understand, and address user needs.
 
-# A team activity
+
+## A team activity
 Because a collaborative approach [increases the team’s overall empathy and efficiency](https://18f.gsa.gov/2016/08/16/what-happens-when-the-whole-team-joins-user-interviews/), research is best done as a team activity. This means the entire team, including your agency partners, shares responsibility for: 
 
 - **Research design** — Formulating a research plan, including research questions and interview guides
@@ -39,23 +41,28 @@ Because a collaborative approach [increases the team’s overall empathy and eff
 - **Synthesis** —  Finding patterns and themes across all research activities 
 - **Reporting** — Capturing and communicating findings from the research to partners and stakeholders.
 
-# Research types
+
+## Research types
 On any given project you should only include the research activities that will inform the decisions you plan to make. Broadly speaking, 18F research falls into three categories:
 
 
-### Foundational research
+## Foundational research
    
 Foundational research is the research you do to identify and clarify the team’s objectives, assumptions, and constraints. This includes stakeholder interviews, secondary research, and workshops. Foundational research is primarily (though not exclusively) the domain of [18F Path Analysis](https://github.com/18F/path-analysis) engagements and results in, among other things, a [problem statement](https://github.com/18F/path-analysis/blob/master/approach.md#2-draft-a-problem-statement).
 
-### Generative research
+
+## Generative research
 
 Generative research helps you better frame the problem(s) you’re solving, spark new ideas, and reveal opportunities. Generative research helps you ask: What are our users’ goals, behaviors, and pain points? What is their context? How might we address the problems we’ve identified? What does success look like?
 
-### Evaluative research
+
+## Evaluative research
 
 Evaluative research is the research you do to test assumptions, hypotheses, and the ease of use of design solutions, such as prototypes. Evaluative research helps you ask: Am I building the right thing—or if this research is done regularly, am I building the thing right? Does it meet user needs?
 
-# The process
+
+## The process
+
 The following steps are repeated as necessary throughout each 18F engagement:
 
 1. [Plan]({{site.baseurl}}/research/plan). Agree on the questions you want answered, the methods you’ll employ, how the team will contribute, etc. Decide who should participate.
@@ -64,7 +71,8 @@ The following steps are repeated as necessary throughout each 18F engagement:
 
 3. [Make research actionable]({{site.baseurl}}/research/make-research-actionable). Review the data you’ve collected, look for patterns, write a summary of what you’ve learned, share it broadly, and delete recordings afterward.
 
-# The environment
+
+## The environment
 
 ### Remote
 
@@ -82,7 +90,8 @@ With most projects you’ll conduct an in-person kickoff, during which you may h
 
 We prefer in-person research when we want to better understand the environment in which users normally interact with a government service. We also prefer in-person research when our participants aren’t especially proficient with, or don’t have access to, video conferencing software.
 
-# Good practices
+
+## Good practices
 
 - **[Choose a research lead.](https://docs.google.com/document/d/1A_xAG_bAbq-0vzovnxJKDBoVQufIG-5-lw_h4jzWVGk/edit#)** A research lead is the team member ultimately responsible for setting the research agenda, explaining the team’s methods, tracking the team’s progress, and ensuring research quality. (While the research lead is normally 18F staff at the start, we work with our partners to identify someone on their side before the engagement ends.)
 - **Discuss.** Discuss your research plan and interview guides. Debrief after each session. Make sure to include partners in these discussions, which will go a long way in [getting them on board with research findings](https://18f.gsa.gov/2018/02/06/getting-partners-on-board-with-research-findings/).
@@ -94,4 +103,3 @@ We prefer in-person research when we want to better understand the environment i
   Note: Because some of our work involves creating solutions that are used by government employees, our users are not always the public. Avoid relying on stakeholders to speak on behalf of users, or expecting users to be aware of your stakeholders’ organizational constraints.
 - **Make time for “research operations.”** Continuous research requires ongoing attention to planning, participant recruiting, informing consent, managing data, and more, in addition to time spent on research itself.
 - **Review government-specific considerations.** Government-led research must account for [legal]({{site.baseurl}}/research/legal), [bias]({{site.baseurl}}/research/bias), [ethical]({{site.baseurl}}/research/ethics), and [privacy]({{site.baseurl}}/research/privacy) considerations. Read these documents and engage your team in conversations about how you’ll account for them.
-

--- a/_pages/research/clarify-the-basics.md
+++ b/_pages/research/clarify-the-basics.md
@@ -46,17 +46,17 @@ Because a collaborative approach [increases the team’s overall empathy and eff
 On any given project you should only include the research activities that will inform the decisions you plan to make. Broadly speaking, 18F research falls into three categories:
 
 
-## Foundational research
+### Foundational research
    
 Foundational research is the research you do to identify and clarify the team’s objectives, assumptions, and constraints. This includes stakeholder interviews, secondary research, and workshops. Foundational research is primarily (though not exclusively) the domain of [18F Path Analysis](https://github.com/18F/path-analysis) engagements and results in, among other things, a [problem statement](https://github.com/18F/path-analysis/blob/master/approach.md#2-draft-a-problem-statement).
 
 
-## Generative research
+### Generative research
 
 Generative research helps you better frame the problem(s) you’re solving, spark new ideas, and reveal opportunities. Generative research helps you ask: What are our users’ goals, behaviors, and pain points? What is their context? How might we address the problems we’ve identified? What does success look like?
 
 
-## Evaluative research
+### Evaluative research
 
 Evaluative research is the research you do to test assumptions, hypotheses, and the ease of use of design solutions, such as prototypes. Evaluative research helps you ask: Am I building the right thing—or if this research is done regularly, am I building the thing right? Does it meet user needs?
 

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -5,14 +5,20 @@ permalink: /research/do/
 sidenav: research
 sticky_sidenav: true
 subnav:
-  - text: Supporting documents
-    href: '#set-up-supporting-documents'
-  - text: Make a record
-    href: '#make-a-consistent-usable-record-of-the-session'
-  - text: Prep logistics
-    href: '#prepare-logistics-to-respect-users-time'
-  - text: Talk to the user
-    href: '#make-the-user-comfortable'
+  - text: Reviewing what’s already known
+    href: '#reviewing-whats-already-known'
+  - text: Designing your research sessions
+    href: '#designing-your-research-sessions'
+  - text: Doing a practice session
+    href: '#doing-a-practice-session'
+  - text: Corresponding with participants
+    href: '#corresponding-with-participants'
+  - text: Moderating research sessions
+    href: '#moderating-research-sessions'
+  - text: Debriefing
+    href: '#debriefing'
+  - text: Additional reading
+    href: '#additional-reading'
 ---
 
 [Planning]({{site.baseurl}}/research/plan) research helps you identify the team’s goals, methods, etc. for its research. Doing research involves engaging with previously agreed upon knowledge, participants, and data.
@@ -29,6 +35,7 @@ This article covers tasks agreed to and implied during research planning such as
 - Facilitating research sessions
 
 - Debriefing
+
 
 ## Reviewing what’s already known
 
@@ -360,6 +367,7 @@ Another style of note taking we commonly use is **interaction notes:** when we w
   
 Content audits frequently use **spreadsheet notes:** these are used to track insights and quality of existing content. 
 
+
 ## Debriefing
 
 Debriefing is a useful way to discuss and capture what everyone took away from a session. It is important to debrief shortly after each session, while the details are still fresh in everyone’s minds. Keep in mind, debriefing is not synthesis — unless you're doing continuous synthesis, it's good to keep it descriptive only and move assessment until later in the research process.
@@ -377,6 +385,7 @@ Here are a few high-level things to capture in a debrief:
 - Are there any new people we should talk to? 
 
 You may want to use this [example interview debrief worksheet](https://methods.18f.gov/interview-debrief/); feel free to modify it to your team’s needs. When determining which team members to include, default to a more diverse group. If a team member wasn’t part of the session, their role can be focused on asking questions and documenting. 
+
 
 ## Additional reading
 - [Tips for capturing the best data from user interviews](https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/)

--- a/_pages/research/ethics.md
+++ b/_pages/research/ethics.md
@@ -11,12 +11,12 @@ subnav:
     href: '#responsibility'
   - text: Honesty
     href: '#honesty'
-
 ---
 
 Research provides us with powerful opportunities. The following ethical principles help guide us through some of the choices that this work can present. 
 
 ***Disclaimer:*** *These principles are meant to serve in addition to your basic ethical obligations as public servants. They are for internal use only, and shared in the spirit of open source. If you have questions, contact your supervisor, GSA’s Privacy Office, or Ethics Legal counsel.*
+
 
 ## Respect
 
@@ -55,7 +55,7 @@ We have a responsibility to further the best interests of the people and the cou
 
 - Accounting for diversity and inclusion in your recruiting (for example, by specifically recruiting people who use a screen reader to navigate your website)
 
-- [Protecting participant privacy](({{site.baseurl}}/research/privacy) 
+- [Protecting participant privacy]({{site.baseurl}}/research/privacy) 
 
 
 ## Honesty
@@ -63,6 +63,7 @@ We have a responsibility to further the best interests of the people and the cou
 Design research should never be covert or manipulative. We provide clear descriptions of our data practices in our [Privacy Impact Assessment for Design Research](https://www.gsa.gov/cdnstatic/20181022%20-%20Design%20Research%20PIA_posted%20version.pdf).
 
 ### Demonstrate this principle by:
+
 - Acknowledge that all research is subject to [bias]({{site.baseurl}}/research/bias), and actively work to counter it 
 
 - Be honest about what you can and cannot conclude based on your research. Do not overstate your findings.

--- a/_pages/research/legal.md
+++ b/_pages/research/legal.md
@@ -4,6 +4,13 @@ title: Legal
 permalink: /research/legal/
 sidenav: research
 sticky_sidenav: true
+subnav:
+- text: The Antideficiency Act
+  href: '#the-antideficiency-act'
+- text: The Paperwork Reduction Act of 1995
+  href: '#the-paperwork-reduction-act-of-1995'
+- text: Additional questions
+  href: '#additional-questions'
 ---
 
 18F designs our research to account for [The Antideficiency Act](https://www.gao.gov/legal/lawresources/antideficiency.html) and [The Paperwork Reduction Act of 1995 (PRA)](https://www.govinfo.gov/content/pkg/PLAW-104publ13/html/PLAW-104publ13.html), among other laws. This article summarizes what we’ve learned through conversations with [GSA’s Privacy Office](https://www.gsa.gov/reference/gsa-privacy-program) and [GSA’s Office of General Counsel](https://www.gsa.gov/about-us/organization/office-of-general-counsel-overview).
@@ -24,13 +31,11 @@ As a general matter, agency funds are not available to provide [incentives](http
 
 [The Paperwork Reduction Act](https://www.govinfo.gov/content/pkg/PLAW-104publ13/html/PLAW-104publ13.htm) (PRA) is a law governing how federal agencies collect information from the American public. We want to be good stewards of the public’s time, and not overwhelm them with unnecessary or duplicative requests for information. We also want to make sure the data we collect is accurate, helpful, and a good fit for its proposed use. In general, the PRA applies whenever you are requesting the same information from ten or more people over a 12-month period. [Office of Information and Regulatory Affairs](https://www.whitehouse.gov/omb/information-regulatory-affairs/) (OIRA) within the [Office of Management and Budget](https://www.whitehouse.gov/omb/) (OMB) reviews and approves Government collections of information from the public under the PRA.
 
-
 ### Research methods and modes
 
 In their [Flexibilities under the Paperwork Reduction Act](https://obamawhitehouse.archives.gov/sites/default/files/omb/inforeg/pra_flexibilities_memo_7_22_16_finalI.pdf) memo, OIRA says that (emphasis added) “OMB does not generally consider facts or opinions obtained through **direct observation** by an employee or agent of the sponsoring agency or through **non-standardized oral communications** in connection with such direct observations to be information under the PRA.” 
 
 18F UX designers generally comply with PRA by showing preference for qualitative research methods (such as semi-structured interviews and usability tests) and research modes that involve direct observation. Moreover, [we often find that we reach saturation](https://www.nngroup.com/articles/why-you-only-need-to-test-with-5-users/) before speaking with ten or more people (though note that for structured information collections, a response of any kind counts towards the ten; even “no, thank you”). We work with our partner agency’s PRA desk officer whenever we want to collect structured information from ten or more people.
-
 
 ### Intercepts
 

--- a/_pages/research/make-research-actionable.md
+++ b/_pages/research/make-research-actionable.md
@@ -7,8 +7,6 @@ sticky_sidenav: true
 subnav:
   - text: From data to insights
     href: '#from-data-to-insights'
-  - text: De-identifying data
-    href: '#de-identifying data'
   - text: Insights into action
     href: '#insights-into-action'
   - text: Sharing

--- a/_pages/research/make-research-actionable.md
+++ b/_pages/research/make-research-actionable.md
@@ -6,11 +6,19 @@ sidenav: research
 sticky_sidenav: true
 subnav:
   - text: From data to insights
-    href: '#From-data-to-insights'
+    href: '#from-data-to-insights'
+  - text: De-identifying data
+    href: '#de-identifying data'
   - text: Insights into action
-    href: '#Insights-into-action'
+    href: '#insights-into-action'
   - text: Sharing
-    href: '#Sharing'
+    href: '#sharing'
+  - text: Publishing on Github
+    href: '#publishing-on-github'
+  - text: Handing off research responsibly
+    href: '#handing-off-research-responsibly'
+  - text: Additional reading
+    href: '#additional-reading'
 ---
 
 Design research is most valuable when it leads to shared understanding.  Analysis, synthesis, and sharing help us reflect on the data we’ve collected and determine a course of action that involves the broader team.

--- a/_pages/research/plan.md
+++ b/_pages/research/plan.md
@@ -7,15 +7,22 @@ sticky_sidenav: true
 subnav:
   - text: Writing a research plan
     href: '#writing-a-research-plan'
+  - text: Participants and recruiting
+    href: '#participants-and-recruiting'
+  - text: Ethical considerations
+    href: '#ethical-considerations'
+  - text: Outputs and outcomes
+    href: '#outputs-and-outcomes'
   - text: Involving partners in research planning
-    href: '#Involving-partners-in-research-planning'
+    href: '#involving-partners-in-research-planning'
   - text: Documenting research
-    href: '#Documenting-research'
+    href: '#documenting-research'
   - text: Additional reading
-    href: '#Additional-reading'
+    href: '#additional-reading'
 ---
 
 Planning ensures that everyone’s time is respected throughout the research process, and helps the team adapt its approach in response to the real world.
+
 
 ## Writing a research plan
 
@@ -61,7 +68,8 @@ What do you want to learn to make better evidence-based decisions? Research ques
 
 Consider holding a [research alignment workshop](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md) (GSA Staff, see [this document](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#heading=h.aou5xt3rvfpf) or [this presentation](https://docs.google.com/presentation/d/16z-oauPeHeBeVxYS3TFRXGFld4uVUEsUjAFZ87fM_IE/edit#slide=id.g4c9bb7ecb1_0_4)) to help stakeholders share and discuss what they’re interested in learning. Regardless of how you build alignment, focus on the value of obtaining useful information.
 
-### Methods 
+### Methods
+
 Choose one or more methods appropriate for meeting your goals and answering your research questions. Multiple methods can help you challenge or verify information collected from a single source and create a more complete understanding.
 [18F’s Methods](https://methods.18f.gov/) provide an overview of our preferred research and design methods. Use these as a starting point, not as a list of constraints. 
 
@@ -115,6 +123,7 @@ Here’s a sample timeline for a contextual inquiry (on site) followed by eight 
 | Communicating the results | 2 days|
 | Sharing | 1 day |
 
+
 ## Participants and recruiting
 
 Most of 18F’s design research depends on you directly interacting with people. Who those people are matters. Participants are the people you’ll recruit to take part in your research. For planning purposes, recruiting involves identifying target groups and defining your recruitment criteria relative to your research question.
@@ -150,11 +159,13 @@ If you’re doing usability testing, consider the following questions as well:
 
 Regardless of how you arrive at them, review your recruitment criteria with your team. Make sure you’re planning to recruit the right people to help answer your research questions. 
 
+
 ## Ethical considerations
 
 Research affords your team powerful opportunities to both interact with people and explore what’s possible. While 18F’s UX team agrees on our own [ethical principles for design research]({{site.baseurl}}/research/ethics), these are just our own. Discuss and clarify ethical principles with your team and your partners. Note any ethical dilemmas or concerns.
 
 Next, engage your team in a conversation about bias. Bias is always present in research, but you can help mitigate it by discussing the [types of bias]({{site.baseurl}}/research/bias) we actively work to mitigate. Power dynamics are always at play when people interact with government. As a researcher in the federal government, be aware that [people’s willingness to share may change depending on their level of trust](https://18f.gsa.gov/2016/03/10/what-people-think-about-before-sharing-personal-information/) in government. 
+
 
 ## Outputs and outcomes
 
@@ -164,6 +175,7 @@ Before you get started, discuss with your team (including your agency partners) 
 - **Outcomes** are the changes you expect to see through doing the research. Outcomes should tie back to the goals and subgoals listed earlier. How will doing the research impact the product being developed, the people involved, etc.? How will you know?
 
 We follow a lean, iterative process, which allows the team to be more responsive and flexible to redefine outputs based on what the process finds. Avoid overspecifying your outputs, because you have no way of knowing what you’ll find until the research is underway. For example, it’s safer to say “We’ll produce a persona” (a type of artifact) than it is to commit to “We’ll provide 10 useful insights,” because it’s difficult to know how many useful insights the research will produce. That said, discussing possible outputs is useful because it can directly affect how you choose to [document the research](#documenting-research).
+
 
 ## Involving partners in research planning
 
@@ -196,6 +208,7 @@ An example agenda for a research planning meeting might include:
 | Review (or co-create) session materials (such as interview guides, wireframes, or prototypes) | 1:30 |
 | Discuss desired outputs and outcomes | 2:30 | 
 | Establish roles| 3:00pm | 
+
 
 ## Documenting research
 
@@ -235,5 +248,6 @@ Regardless of the method you choose, it’s good to keep in mind the overall rea
 - We create a starting point for analysis and synthesis.
 
 ## Additional reading
+
 - [Examples of past research plans from past 18F projects](https://github.com/18F/Design-Wiki/wiki/Research-Protocol)
 

--- a/_pages/research/privacy.md
+++ b/_pages/research/privacy.md
@@ -5,6 +5,8 @@ permalink: /research/privacy/
 sidenav: research
 sticky_sidenav: true
 subnav:
+  - text: Personally Identifiable Information (PII) 
+    href: '#personally-identifiable-information-pii'
   - text: Guidelines
     href: '#guidelines'
   - text: Additional reading
@@ -14,6 +16,7 @@ subnav:
 18F’s research practices are grounded in building and maintaining trust.  When participants trust us they are more likely to share full and accurate accounts of their experiences. A large part of maintaining participant trust involves protecting participant privacy. 
 
 ***Disclaimer:*** *This page is intended for internal use. It is shared in the spirit of open source, to prompt conversations around design research as it relates to privacy. GSA has no regulatory authority over any of the laws discussed in this section, so don’t just take our word for it.*
+
 
 ## Personally Identifiable Information (PII) 
 
@@ -31,6 +34,7 @@ Each piece of collected or stored PII increases the risk of privacy violations. 
 - Protect agency-held PII against anticipated threats to security or integrity which could result in substantial harm, embarrassment, inconvenience or unfairness to the participant.
 
 18F complies with the Privacy Act by following the information practices outlined in our [Privacy Impact Assessment for Design Research](https://www.gsa.gov/cdnstatic/20181022%20-%20Design%20Research%20PIA_posted%20version.pdf). The [TTS Research Guild](https://github.com/18F/g-research) works with the [GSA Privacy Office](https://www.gsa.gov/reference/gsa-privacy-program) to annually review this assessment.
+
 
 ## Guidelines
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -17,7 +17,6 @@ subnav:
     href: '#presentations-gsa-only'
   - text: Additional reading
     href: '#additional-reading'
-
 ---
 
 We’ve collected the following templates, presentations, checklists, etc. as starting points — feel free to [contribute to this guide](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md) and help us keep this list up-to-date!

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -4,6 +4,20 @@ title: Resources
 permalink: /resources/
 sidenav: overview
 sticky_sidenav: true
+subnav:
+  - text: Research
+    href: '#research'
+  - text: Email templates
+    href: '#email-templates'
+  - text: Design
+    href: '#design'
+  - text: General
+    href: '#general'
+  - text: Presentations (GSA only)
+    href: '#presentations-gsa-only'
+  - text: Additional reading
+    href: '#additional-reading'
+
 ---
 
 We’ve collected the following templates, presentations, checklists, etc. as starting points — feel free to [contribute to this guide](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md) and help us keep this list up-to-date!

--- a/index.md
+++ b/index.md
@@ -4,6 +4,15 @@ title: About this guide
 permalink: /
 sidenav: overview
 sticky_sidenav: true
+subnav:
+  - text: What this guide is
+    href: '#what-this-guide-is'
+  - text: How to use this guide
+    href: '#how-to-use-this-guide'
+  - text: Reusing this guide
+    href: '#reusing-this-guide-in-other-organizations'
+  - text: References
+    href: '#references'
 ---
 
 18F user experience (UX) designers join cross-functional teams to improve interactions between government agencies and the people they serve. The 18F UX Guide helps us get this job done. It’s a starting point for UX design at 18F: doing it, discussing it, and ensuring it’s done to a consistent level of quality.


### PR DESCRIPTION
**Why:** As a user, I would like the UX Guide to reduce the burden of navigating through very lengthy content. (#171)

[Preview via Federalist](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/nng-add-h2-headings-to-subnav/)

**How:** Move to include every H2 in the subnav throughout the site

**Additional fixes/updates:**
- Fix multiple H1 headings in `clarify-the-basics.md`
- Clean up format for consistency throughout markdown files

**Question:** The `our-approach/defining-design/` content has multiple 'H3' headings (no H2 headings). Is it intentional? Or should we reformat the H3 headings to H2 headings? 

**When reviewing:**
- [x] Test that every subnav headings are linked correctly
- [x] Check for typos
- [x] Test view widths to ensure that there are no awkward borkiness
- [x] Each subnav makes sense and is clear

When done: Close #171 