### PR TITLE
Reposition sidenav to top on mobile

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -157,15 +157,21 @@ a[href^="https://gsa-tts.slack.com"]::before {
 
 .usa-layout-docs__sidenav {
   overflow: visible;
+  order: 0;
+  margin-bottom: units(3);
+  padding-top: 0;
+  position: relative;
 }
 
 .usa-header .usa-logo a {
   display: inline-block;
 }
 
+
 @include at-media("desktop") {
   .usa-layout-docs__sidenav {
     @include grid-col(3);
+    position: sticky;
   }
 
   .usa-layout-docs__main {


### PR DESCRIPTION
This PR addresses #182 and places the sidnav on top of the pages on smaller screens. 

👓   [Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/ik-sidenav-position/)  

The sidenav is now full width as well (I believe that's thanks to Dan's updates). 


