### PR TITLE
Add search.gov site handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,9 @@ plugins:
 google_analytics_ua: UA-48605964-19
 dap_agency: GSA
 
+# Add search site handle to enable search
+search_site_handle: uxguide
+
 scripts:
   - assets/uswds/js/uswds.min.js
   - javascripts/private-eye.js


### PR DESCRIPTION
This PR is in service of #159 , and adds a search handle to the config file so that the search box is visible and active. 
👓 &nbsp;[Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/ik-add-search/)