### PR TITLE
Ik add search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,9 @@ plugins:
 google_analytics_ua: UA-48605964-19
 dap_agency: GSA
 
+# Add search site handle to enable search
+search_site_handle: uxguide
+
 scripts:
   - assets/uswds/js/uswds.min.js
   - javascripts/private-eye.js

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ google_analytics_ua: UA-48605964-19
 dap_agency: GSA
 
 # Add search site handle to enable search
-search_site_handle: uxguide
+search_site_handle: ux-guide.18f.gov
 
 scripts:
   - assets/uswds/js/uswds.min.js

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -70,6 +70,10 @@ a:hover {
   height: 0;
 }
 
+.usa-nav__secondary-links {
+  display: none;
+}
+
 // usa-sidenav
 
 .usa-sidenav a {


### PR DESCRIPTION
This draft PR addresses #159 . I was able to add the site-handle to our config and the search box is now functional
👓 &nbsp;[Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/ik-add-search/)

However, there are cases where it returns results to pages that are unstyled. For instance searching for "Interviews", the first three results have pages that have no or incorrect styling. 

I think this is because the permalink for those pages is just `/page-name` instead of their section name `/section/page-name`. So perhaps adding in the section name to the permalink may solve the issue. For instance changing the permalink for the `interview-checklist` to  `/resources/interview-checklist/` But I am not totally sure.

@nickttng thoughts?