### PR TITLE
Patch menu menu issue (Temporary fix)

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -173,7 +173,6 @@ a[href^="https://gsa-tts.slack.com"]::before {
   display: inline-block;
 }
 
-
 @include at-media("desktop") {
   .usa-layout-docs__sidenav {
     @include grid-col(3);
@@ -186,9 +185,9 @@ a[href^="https://gsa-tts.slack.com"]::before {
 }
 
 
-////Footer (usa-anchor styles)
+//// Footer (usa-anchor styles)
 
-//fixing footer anchor to bottom
+// Fixing footer anchor to bottom
 body {
   display: flex;
   flex-direction: column;

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -188,10 +188,12 @@ a[href^="https://gsa-tts.slack.com"]::before {
 //// Footer (usa-anchor styles)
 
 // Fixing footer anchor to bottom
-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+@include at-media("desktop") {
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
 }
 
 @import '_usa_anchor';


### PR DESCRIPTION
**Why:** When the PR #174 was merged, it introduced an issue, which the mobile menu navigation is darkened and the nav items are not clickable (See screenshot). We need to have a temporary patch in time for the launch, and find a better, permanent solution after the launch.

<img width="231" alt="ux-guide 18f gov_mobile-menu" src="https://user-images.githubusercontent.com/6327082/89220184-be230c00-d596-11ea-9f91-1995a778a651.png">

**How:**

1. Identified a conflict between `body { display: flex; ... }` in `_uswds-theme-custom-styles.scss` and `usa-js-mobile-nav--active`, which both are used in `body` 
2. Created a temporary patch via `@include at-media("desktop")` media rule, so that the `display: flex` is set to enable sticky footer only on desktop until we figure out the mobile/tablet solution

🕶️  → [Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/nng-temp-patch-mobile-menu/) 

**Next steps:**

- [x] Review and merge
- [ ] Create a GH issue to track this and find a better, permanent solution
  - [ ] Find a solution that enables sticky on both mobile and tablet

