### PR TITLE
Remove extra '}' in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,7 @@
                 <img src="{{site.baseurl}}/images/{{ anchor.agency_logo }}" class="org-img" alt="{{ anchor.agency }} Logo" %}></a>
               <a href="{{ anchor.org_secondary_url }}" title="{{ anchor.org_secondary }}">
                 <img src="{{site.baseurl}}/images/{{ anchor.org_secondary_logo }}" class="org-img" alt="{{ anchor.org_secondary }} Logo" %}></a>
-              <p><a href="{{site.baseurl}}}" title="{{ anchor.site_name }}">{{ anchor.site_name -}}</a> is a product of {{ anchor.agency_acronym }}&#8217;s <a href="{{ anchor.org_primary_url }}" title="{{ anchor.org_primary }}">{{ anchor.org_primary }}</a>{%if anchor.org_primary %}, and is managed by <a href="{{ anchor.org_secondary_url }}" title="{{ anchor.org_secondary }}">{{ anchor.org_secondary }}</a>{%endif%}.</p>
+              <p><a href="{{site.baseurl}}" title="{{ anchor.site_name }}">{{ anchor.site_name -}}</a> is a product of {{ anchor.agency_acronym }}&#8217;s <a href="{{ anchor.org_primary_url }}" title="{{ anchor.org_primary }}">{{ anchor.org_primary }}</a>{%if anchor.org_primary %}, and is managed by <a href="{{ anchor.org_secondary_url }}" title="{{ anchor.org_secondary }}">{{ anchor.org_secondary }}</a>{%endif%}.</p>
             </div>
             <button class="btn-learn-more usa-button usa-button--outline usa-button--inverse usa-accordion__button" aria-hidden="false" aria-expanded="false" aria-controls="org-details">
               <span>Learn&nbsp;more</span>


### PR DESCRIPTION
This PR removes and extra '}' to fix the broken "18F UX guide" link in the footer 

🕶️ &nbsp;[Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/ik-footer-homelink-patch/)