### PR TITLE
Correct `accessiblity` typo to `accessibility`

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
                 <li><a href="{{ anchor.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">Report fraud, waste, or abuse to the Office of the Inspector General</a></li>
                 <li><a href="{{ anchor.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">Submit a Freedom of Information Act (FOIA) request</a></li>
                 <li><a href="{{ anchor.budget_performance_url }}" title="View budget and performance reports">View budget and performance reports</a></li>
-                <li><a href="{{ anchor.accessibility_url }}" title="View accessiblity statement">View accessiblity statement</a></li>
+                <li><a href="{{ anchor.accessibility_url }}" title="View accessibility statement">View accessibility statement</a></li>
                 <li><a href="{{ anchor.no_fear_act_url }}" title="View No FEAR Act data">View No FEAR Act data</a></li>
               </ul>
             </div>


### PR DESCRIPTION
**Why:** Correct the typo from `accessiblity` (see current screenshot below) to `accessibility`

![ux-guide-typo-accessibility](https://user-images.githubusercontent.com/6327082/90347574-ff83d480-dff6-11ea-8640-841b08afabbc.png)

_Note:_ This typo also appears on [digital.gov](https://digital.gov/) footer, so this might be widespread.
