### PR TITLE
Adds missing footer word

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,7 +54,7 @@
     <div class="grid-row tablet-lg:grid-gap-2">
       <div class="grid-col-12">
         <div class="usagov">
-          <span>Looking for U.S. government and services?</span></p>
+          <span>Looking for U.S. government information and services?</span></p>
           <a class="usa-link usagov__link" href="{{ anchor.usagov_contact_url }}?ref={{ anchor.site_name }}">Visit USA.gov</a>
         </div>
       </div>


### PR DESCRIPTION
Because we shamelessly copied your work for the content guide updates, we happened to notice a missing word in the footer:

`Looking for U.S. government and services?`

This PR changes to:

`Looking for U.S. government information and services?`

