### PR TITLE
Update resources.md

### DIFF
--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -29,6 +29,9 @@ Prompts for planning research. Pairs well with our [research planning]({{site.ba
 [Research alignment workshop](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md) ([Gdoc](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#))  
 A workshop template for publicizing team questions and prioritizing research themes, setting you up to create a research plan that drives maximum value for your team.
 
+[Usability test quality heuristics](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md) ([Gdoc](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit))  
+A list of indicators to help you and your team determine if your usability test will produce useful results. 
+
 [Design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md) ([GDoc](https://drive.google.com/open?id=16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo))  
 Our agreement for anyone participating in moderated design research.  
 Note: This document is a template; you can customize it however you like so long as your agreement includes an Antideficiency Act clause.
@@ -107,7 +110,6 @@ We most commonly share our work via presentations. These presentations can vary 
 - [List of prior path analyses](https://github.com/18F/path-analysis/blob/master/projects.md)
 - [Project resources folder](https://drive.google.com/drive/folders/1L9qqS6-b-emvlWJ4JPCG58LW62bbV361)
 - [Six weird tips for protecting PII](https://drive.google.com/a/gsa.gov/open?id=1MM6tNlFc-Iwgw_cCUw_0KS8oQMS-FEN7sYftPQLmLAg)
-- [Usability test quality heuristics](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)
 - [Artifacts from design-led projects](https://drive.google.com/drive/folders/1NZG-bxIeFiOw0sAn32a4APJc_TipCrQp)
 - [Checklist of requirements for federal government websites](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/)
 - [Quickstart: Intercept (pop-up) research in GSA buildings](https://docs.google.com/document/d/1ph3fP2rGr0FeXSeueRD4YmIJYF3f-3yIoI-uDz6iwsI/edit#heading=h.ssdnqe2zdwhz)


### PR DESCRIPTION
As per issue #221, added a link to the [markdown version of Usability test quality heuristics](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md), to the [Gdoc version](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit), and removed it from the list of [General resources](https://ux-guide.18f.gov/resources/#general) further down on the page to reduce duplication.