### PR TITLE
add DAP subagency #226

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ plugins:
 # Google Analytics & DAP tracking code for handbook
 google_analytics_ua: UA-48605964-19
 dap_agency: GSA
+dap_subagency: TTS,18F
 
 # Add search site handle to enable search
 search_site_handle: ux-guide.18f.gov


### PR DESCRIPTION
closes #226 

To test:
- [x] Chrome extension Google Tag Assistant shows that the tag is sending data
- [ ] 48 hours post-deploy, DAP Google Analytics shows data is coming through.