### PR TITLE
Redirects for pages appearing empty from search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'uswds-jekyll', '~> 5.0'
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       terminal-table (~> 1.8)
     jekyll-feed (0.15.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -69,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0)
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   jekyll-sitemap
   tzinfo-data
   uswds-jekyll (~> 5.0)

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="refresh" content="0;url={{ page.redirect|prepend:site.baseurl }}" />
+    <meta http-equiv="refresh" content="0;url={{ page.redirect }}" />
   </head>
   <h1>Redirecting...</h1>
   <p>If your browser doesn&rsquo;t redirect automatically, you can

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="refresh" content="0;url={{ page.redirect|prepend:site.baseurl }}" />
+  </head>
+  <h1>Redirecting...</h1>
+  <p>If your browser doesn&rsquo;t redirect automatically, you can
+    <a href="{{ page.redirect|prepend:site.baseurl }}">do it manually</a>.</p>
+</html>

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -205,7 +205,12 @@ Getting informed consent ensures that:
 - The research complies with The Privacy Act of 1974 (see [Privacy]({{site.baseurl}}/research/privacy))
 - The research complies with The Antideficiency Act (see [Legal]({{site.baseurl}}/research/legal))
 
-Copy and customize [this example design research participant agreement](https://methods.18f.gov/participant-agreement/) ([Google Docs version of template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) ([Spanish version of design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md)) or [Google form version](https://docs.google.com/forms/d/13ra4T0BVWbjSPBfOuNj8zVclU5J4TquX_tFbHUQWUpc/edit)) to reflect your research design. This is the agreement you'll ask participants to sign before they participate.
+Copy and customize one of the participant agreements below to reflect your research design. This is the agreement you'll ask participants to sign before they participate.
+
+- [Example design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md)
+- [For GSA staff: Google Doc participant agreement](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit)
+- [Spanish version of participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md)
+- [For GSA staff: Google Doc Spanish version of participant agreement](https://docs.google.com/forms/d/13ra4T0BVWbjSPBfOuNj8zVclU5J4TquX_tFbHUQWUpc/edit))
 
 Correspond with participants ahead of time to explain things that might otherwise get lost in the agreement-signing process. In the event that a participant has not signed an agreement ahead of the interview, obtain their verbal consent. In order to give their informed consent, participants need to understand:
 
@@ -226,8 +231,8 @@ You must also let participants know:
 
 There are two email templates available to help with participant correspondence:
 
-1. [Template for introducing yourself](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md)<br />([Google Docs version of email introducing yourself](https://drive.google.com/open?id=1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg))
-2. [Template for passing along a participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md)<br /> ([Google Docs version of email to accompany participant agreement](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit)).
+1. [Template for introducing yourself](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md)<br />([For GSA Staff: Google Doc of email introducing yourself](https://drive.google.com/open?id=1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg))
+2. [Template for passing along a participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md)<br /> ([For GSA Staff: Google Doc of email to accompany participant agreement](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit)).
 
 Remember to cover the information listed above. Ask participants if they have any questions. Ensure they don’t feel pressure to participate in ways that make them uncomfortable.
 
@@ -259,7 +264,7 @@ Also remember to:
     - Download and install any necessary software (eg. Zoom if you are using Zoom for your sessions)
 - If you conduct research sessions via Google Meet and initiate a screen recording, the video will be saved to the Google Drive of the person who created the meeting. A link to the video will be added to the calendar event after the meeting.
 
-Your agency partners can often assist in the scheduling process, particularly when setting up sessions with stakeholders. Don’t hesitate to ask them for help! You can provide them with a tailored version of this [email where stakeholder introduces researcher](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md). ([Google docs version of email](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).
+Your agency partners can often assist in the scheduling process, particularly when setting up sessions with stakeholders. Don’t hesitate to ask them for help! You can provide them with a tailored version of this [email where stakeholder introduces researcher](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md). ([For GSA Staff: Google Doc of stakeholder email to introduce researcher ](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).
 
 ## Moderating research sessions
 
@@ -272,7 +277,7 @@ Before each session, you should double-check:
 - Your primary documentation method
 - That you have a backup documentation method (such as a notepad and a pen)
 
-Moderating a research session can be nuanced, but we encourage all team members to be involved. Make sure participants are comfortable and that facilitators, notetakers, and other team members are prepared. We created [a checklist of best practices for interviews](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md). ([Google docs version of the checklist](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)). The checklist includes:
+Moderating a research session can be nuanced, but we encourage all team members to be involved. Make sure participants are comfortable and that facilitators, notetakers, and other team members are prepared. We created [a checklist of best practices for interviews](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md). ([For GSA Staff: Google Doc of checklist](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)). The checklist includes:
 
 {:.list-item--margin-bottom-extra}
 - Keep an eye on the time. Decide beforehand which questions or activities you must cover and which ones you can cut if you run out of time.
@@ -281,7 +286,7 @@ Moderating a research session can be nuanced, but we encourage all team members 
 - Allow time for notetakers or observers to ask follow-up questions. Leave time for the interviewee to ask questions of the team as well.
 - If appropriate, ask if they know others who would be good for your team to talk to.
 
-While UX Designers heavily utilize interviews, we also use a variety of other methods. Tips for moderating these can be found in the [18F Method Cards](https://methods.18f.gov). We’ve also created a breakdown of [usability testing quality heuristics](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit#heading=h.y2rdboc1uj3o). If you’re interested in developing more guides, the research guild is a great place to find collaborators.
+While UX Designers heavily utilize interviews, we also use a variety of other methods. Tips for moderating other methods can be found in the [18F Method Cards](https://methods.18f.gov). We’ve also created a breakdown of [usability test quality heuristics](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md) ([For GSA Staff: Google Doc of heuristics](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)). For Technology Transformation Services staff interested in developing additional methods, the [Research guild (#g-research)](https://gsa-tts.slack.com/messages/g-research) is a great place to find collaborators.
 
 ### Tips for remote research
 

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -102,7 +102,7 @@ In evaluative research such as [usability testing](https://methods.18f.gov/valid
 
 {:.list-item--margin-bottom-extra}
 1. **Clarify the tasks your sessions will investigate.** Tasks are often included in artifacts such as personas or user stories. If your team doesn’t yet have those artifacts, ask them to identify “the most essential things that people need to do” relative to your research area of focus. Then pick the top two or three tasks the prototype will need to depict.
-2. **Prepare a scenario for each task.** Scenarios help your team create a more believable prototype; they also help moderators prepare research participants during the sessions themselves. If applicable, incorporate your scenarios into the guide you’ll use to moderate the session. [Here’s a boilerplate usability test guide](https://methods.18f.gov/usability-test-script/) ([Google Docs version](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/edit#heading=h.cb9ci3qbjc56)).
+2. **Prepare a scenario for each task.** Scenarios help your team create a more believable prototype; they also help moderators prepare research participants during the sessions themselves. If applicable, incorporate your scenarios into the guide you’ll use to moderate the session. [Here’s a boilerplate usability test guide](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-guide.md) ([Google Docs version](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/edit#heading=h.cb9ci3qbjc56)).
 3. **Discuss with your team how and when you’ll share the prototype** (for example, sharing a link to an online prototype or sending a document).
 
 Prototypes create dependencies in your research. When doing research involving prototypes, you will need to:
@@ -183,13 +183,13 @@ The third and final step is identifying interested people and determine if they 
 
 ### Incentives
 
-We now have the ability to compensate user testing participants so long as they are public participants, not government employees. This major advancement for research and human-centered design makes it possible for us to get input from more representative groups of people in order to better deliver products and services. Our ability to compensate users for testing depends on both obtaining authorization from the agency partner with the appropriate level of authority and meeting the following criteria: 
+We now have the ability to compensate user testing participants so long as they are public participants, not government employees. This major advancement for research and human-centered design makes it possible for us to get input from more representative groups of people in order to better deliver products and services. Our ability to compensate users for testing depends on both obtaining authorization from the agency partner with the appropriate level of authority and meeting the following criteria:
 
-1. The benefit to the government in obtaining the feedback outweighs the benefit to the participant 
-   (i.e., amount paid to   the user) 
+1. The benefit to the government in obtaining the feedback outweighs the benefit to the participant
+   (i.e., amount paid to   the user)
 2. Compensating user testing participants must directly advance the client’s statutory mission and objectives
 
-The process of paying participants for research is similar to paying for a contractor or vendor. TTS will continue to iterate on this approach in partnership with OGC. We are currently [collecting value statements](https://docs.google.com/forms/d/e/1FAIpQLSf4k7MQuQjD71O6GsK6-c_3ByWMtUskhYEt6hcrq2qYEqSZNw/viewform) that might be useful in demonstrating eligibility for the “benefit to government” portion of the criteria. 
+The process of paying participants for research is similar to paying for a contractor or vendor. TTS will continue to iterate on this approach in partnership with OGC. We are currently [collecting value statements](https://docs.google.com/forms/d/e/1FAIpQLSf4k7MQuQjD71O6GsK6-c_3ByWMtUskhYEt6hcrq2qYEqSZNw/viewform) that might be useful in demonstrating eligibility for the “benefit to government” portion of the criteria.
 
 More detailed information can be found in the [Compensating research participants document.](https://docs.google.com/document/d/1oWDxVUsRbO1ELNmni3Qa-uYPhXDWuNM3HESgAUxs7Uw/edit)
 In order to add compensation for participants to your in-flight engagement or new IAA, you can use the above resource, which includes the [User Testing Authorization, Attachment 2 - CoE - {{Agency}} document.](https://docs.google.com/document/d/16t7vczeoN_fpTCrrQ2Kvjdb9r_fMywebeDKshRcSfqM/edit#)  
@@ -205,7 +205,7 @@ Getting informed consent ensures that:
 - The research complies with The Privacy Act of 1974 (see [Privacy]({{site.baseurl}}/research/privacy))
 - The research complies with The Antideficiency Act (see [Legal]({{site.baseurl}}/research/legal))
 
-Copy and customize [this example design research participant agreement](https://methods.18f.gov/participant-agreement/) ([Google Docs version of template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) or [Google form version](https://docs.google.com/forms/d/13ra4T0BVWbjSPBfOuNj8zVclU5J4TquX_tFbHUQWUpc/edit)) to reflect your research design. This is the agreement you'll ask participants to sign before they participate.
+Copy and customize [this example design research participant agreement](https://methods.18f.gov/participant-agreement/) ([Google Docs version of template](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) ([Spanish version of design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md)) or [Google form version](https://docs.google.com/forms/d/13ra4T0BVWbjSPBfOuNj8zVclU5J4TquX_tFbHUQWUpc/edit)) to reflect your research design. This is the agreement you'll ask participants to sign before they participate.
 
 Correspond with participants ahead of time to explain things that might otherwise get lost in the agreement-signing process. In the event that a participant has not signed an agreement ahead of the interview, obtain their verbal consent. In order to give their informed consent, participants need to understand:
 
@@ -336,7 +336,7 @@ Here are a few high-level things to capture in a debrief:
 - What new questions do we have?
 - Are there any new people we should talk to?
 
-You may want to use this [example interview debrief worksheet](https://methods.18f.gov/interview-debrief/); feel free to modify it to your team’s needs. When determining which team members to include, default to a more diverse group. If a team member wasn’t part of the session, their role can be focused on asking questions and documenting.
+You may want to use this [example interview debrief worksheet](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief-guide.md); feel free to modify it to your team’s needs. When determining which team members to include, default to a more diverse group. If a team member wasn’t part of the session, their role can be focused on asking questions and documenting.
 
 
 ## Additional reading

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -30,9 +30,10 @@ Prompts for planning research. Pairs well with our [research planning]({{site.ba
 A workshop template for publicizing team questions and prioritizing research themes, setting you up to create a research plan that drives maximum value for your team.
 
 [Usability test quality heuristics](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md) ([Gdoc](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit))  
-A list of indicators to help you and your team determine if your usability test will produce useful results. 
+A list of indicators to help you and your team determine if your usability test will produce useful results.
 
 [Design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md) ([GDoc](https://drive.google.com/open?id=16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo))  
+[Design research participant agreement in Spanish](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md)
 Our agreement for anyone participating in moderated design research.  
 Note: This document is a template; you can customize it however you like so long as your agreement includes an Antideficiency Act clause.
 
@@ -79,18 +80,18 @@ You can also participate in local communities of practice in by joining:
 
 ### Microrequests
 
-If you’re in need of a particular skill — help with a presentation or design deliverable; writing and content strategy; or development tasks — 18F’s microrequest staffing team can provide support. You can request assistance from 18F colleagues for help on billable projects in the [#microrequests](https://gsa-tts.slack.com/app_redirect?channel=microrequests) channel. Each discipline is represented at any time in the channel. 
+If you’re in need of a particular skill — help with a presentation or design deliverable; writing and content strategy; or development tasks — 18F’s microrequest staffing team can provide support. You can request assistance from 18F colleagues for help on billable projects in the [#microrequests](https://gsa-tts.slack.com/app_redirect?channel=microrequests) channel. Each discipline is represented at any time in the channel.
 
-Any billable project work is eligible for assistance via a microrequest. The only limitation is that microrequest tasks must typically take fewer than 8 hours of work a week, over no more than 3 weeks, for the person providing the assistance. You may post non-billable requests in the [#helpwanted](https://gsa-tts.slack.com/app_redirect?channel=helpwanted) channel. 
+Any billable project work is eligible for assistance via a microrequest. The only limitation is that microrequest tasks must typically take fewer than 8 hours of work a week, over no more than 3 weeks, for the person providing the assistance. You may post non-billable requests in the [#helpwanted](https://gsa-tts.slack.com/app_redirect?channel=helpwanted) channel.
 
 For more information, visit the [Microrequests](https://handbook.tts.gsa.gov/microrequests/) page in the [TTS Handbook](https://handbook.tts.gsa.gov/).
 
 ### Presenting the work
 We most commonly share our work via presentations. These presentations can vary widely based on the audience. Here are a few presentation-building tips:
 
-* Utilize our [18F-branded templates](https://brand.18f.gov/templates/) to maintain consistency and save time. 
-* The presentation deck should tell a compelling story and be easy to read. Make sure to include enough content so those not able to attend the presentation can view the deck later and understand what you’re aiming to communicate. Refer to this presentation on [How to design a better deck](https://docs.google.com/presentation/d/1WMbN1feG1bMhaFx5YbXoYUTE7xgZdMewMaQBZeL3YmA/edit#slide=id.g58dd554fac_0_397) for additional pointers and guidance. 
-* Check out the [Project resources folder](https://drive.google.com/drive/folders/1L9qqS6-b-emvlWJ4JPCG58LW62bbV361) for reusable content and templates; browse [previous 18F Path Analysis project artifacts](https://github.com/18F/project-artifacts/blob/master/projects.md) for inspiration; or view the [Design wiki](https://github.com/18F/Design-Wiki/wiki) for additional examples. 
+* Utilize our [18F-branded templates](https://brand.18f.gov/templates/) to maintain consistency and save time.
+* The presentation deck should tell a compelling story and be easy to read. Make sure to include enough content so those not able to attend the presentation can view the deck later and understand what you’re aiming to communicate. Refer to this presentation on [How to design a better deck](https://docs.google.com/presentation/d/1WMbN1feG1bMhaFx5YbXoYUTE7xgZdMewMaQBZeL3YmA/edit#slide=id.g58dd554fac_0_397) for additional pointers and guidance.
+* Check out the [Project resources folder](https://drive.google.com/drive/folders/1L9qqS6-b-emvlWJ4JPCG58LW62bbV361) for reusable content and templates; browse [previous 18F Path Analysis project artifacts](https://github.com/18F/project-artifacts/blob/master/projects.md) for inspiration; or view the [Design wiki](https://github.com/18F/Design-Wiki/wiki) for additional examples.
 * Consider making a [microrequest](https://handbook.tts.gsa.gov/microrequests/) if you’re unsure how to articulate or visualize an idea.
 * Feel free to include references or links to further reading at the end of your presentation.
 

--- a/_pages/resources/assisting-in-research.md
+++ b/_pages/resources/assisting-in-research.md
@@ -1,9 +1,10 @@
 ---
 permalink: /research/assist/
-layout: post
+layout: redirect
 title: Assisting in research
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/assisting-in-research.md
 ---
 
 # Assisting in research
@@ -16,9 +17,9 @@ Thanks for offering to assist in research. At a high level, you will likely be e
 Before the research begins, work with the [research lead](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md) to understand the research design and how you can best offer assistance:
 
 1. Ask the research lead for a copy of the [research plan](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md), [interview guide](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-script.md), and/or access to concepts (wireframes, prototypes, etc.) being tested
-1. Review these materials, and note any questions
-1. Schedule a meeting with the research lead to run a practice session, and clarify any points of confusion
+2. Review these materials, and note any questions
+3. Schedule a meeting with the research lead to run a practice session, and clarify any points of confusion
 
-In addition to serving to clarify the research design, this meeting helps ensure that, in the heat of the moment, you are more likely to correctly interpret interactions between the moderator and the participant. 
+In addition to serving to clarify the research design, this meeting helps ensure that, in the heat of the moment, you are more likely to correctly interpret interactions between the moderator and the participant.
 
 After each session you may be invited to participate in post-interview debrief to discuss what you heard and saw, and to discuss ways the research lead might improve the test design going forward.

--- a/_pages/resources/email-templates/researcher-introduces-themselves.md
+++ b/_pages/resources/email-templates/researcher-introduces-themselves.md
@@ -1,9 +1,10 @@
 ---
 permalink: /resources/email-templates/researcher-introduces-themselves
-layout: post
+layout: redirect
 title: Email template - Researcher introduces themselves to a participant
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md
 ---
 
 Hey `[Participant name]`,  

--- a/_pages/resources/email-templates/researcher-sends-agreement.md
+++ b/_pages/resources/email-templates/researcher-sends-agreement.md
@@ -1,9 +1,10 @@
 ---
 permalink: /resources/email-templates/researcher-sends-agreement
-layout: post
+layout: redirect
 title: Email template - Researcher sends agreement to a participant
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md
 ---
 
 Hey `[Participant name]`,  

--- a/_pages/resources/email-templates/stakeholder-introduces-researcher.md
+++ b/_pages/resources/email-templates/stakeholder-introduces-researcher.md
@@ -1,9 +1,10 @@
 ---
 permalink: /resources/email-templates/stakeholder-introduces-researcher
-layout: post
+layout: redirect
 title: Email template - Stakeholder introduces researcher
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md
 ---
 
 Hi `[Colleagues]`,  

--- a/_pages/resources/interview-checklist.md
+++ b/_pages/resources/interview-checklist.md
@@ -1,8 +1,9 @@
 ---
 title: Interview checklist
 description: Helpful reminders for moderating interviews
-layout: page
+layout: redirect
 permalink: /interview-checklist/
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md
 ---
 
 # Interview checklist

--- a/_pages/resources/interview-debrief-guide.md
+++ b/_pages/resources/interview-debrief-guide.md
@@ -1,8 +1,9 @@
 ---
 title: Interview Debrief Guide [Template]
 description: An example worksheet to engage research teams in post-moderated research conversation
-layout: page
+layout: redirect
 permalink: /interview-debrief/
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief-guide.md
 ---
 
 # Interview Debrief Guide [Template]

--- a/_pages/resources/interview-guide.md
+++ b/_pages/resources/interview-guide.md
@@ -1,8 +1,9 @@
 ---
 title: Interview guide [template]
 description: An example script for use while leading a user interview
-layout: page
+layout: redirect
 permalink: /interview-script/
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-guide.md
 ---
 
 # Interview guide [template]

--- a/_pages/resources/participant-agreement-spanish.md
+++ b/_pages/resources/participant-agreement-spanish.md
@@ -1,9 +1,9 @@
 ---
 title: Example Design Research Participant Agreement — Spanish
 description: An example design research participant agreement in Spanish
-layout: page
+layout: redirect
 permalink: /participant-agreement-spanish/
-
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md
 ---
 
 # Ejemplo del acuerdo para participantes en un estudio de diseño
@@ -17,7 +17,7 @@ Este acuerdo está vinculado con su participación en un estudio dirigido por `<
 
 ---
 
-- **Usted puede optar por no participar.** Si en algún momento ya no desea participar, informe al moderador del estudio. No hay ningún problema. 
+- **Usted puede optar por no participar.** Si en algún momento ya no desea participar, informe al moderador del estudio. No hay ningún problema.
 - **No se le pagará ni recibirá compensación por su participación.** Acepta realizar todas las tareas asociadas con su participación en este estudio durante el período de `<fecha de inicio del proyecto>` - `<fecha de finalización del proyecto>` sin expectativa de pago. Usted reconoce que no recibirá, y no espera recibir, ni el pago ni ninguna otra forma de compensación por su participación en este estudio. Usted renuncia a un reclamo u otro recurso en contra de `<organización>` relacionado con la compensación por su participación en este estudio.
 - **`<organización>` tiene permiso para grabar este estudio.** `<organización>` tiene permiso para hacer grabaciones de video, audio, fotográficas y escritas de este estudio. Estos registros se guardarán en un lugar seguro y se compartirán únicamente con personas con una necesidad válida de saber los datos.
 - **`<organización>` tomará las precauciones apropiadas para proteger su privacidad,** como se explica en nuestra Declaración de la Ley de Privacidad y en la Evaluación del Impacto de la Privacidad. A menos que se acuerde lo contrario, `<organización>` tomará los pasos apropiados para eliminar la información confidencial y la identificación personal capturada durante el estudio.
@@ -25,7 +25,7 @@ Este acuerdo está vinculado con su participación en un estudio dirigido por `<
 ---
 
 Al firmar este documento, usted acepta leerlo, comprenderlo y aceptarlo. Usted libera expresamente a `<organización>` de y contra cualquier y todos los reclamos que tenga o pueda tener por compensación, invasión de privacidad, difamación o cualquier otra causa de acción que surja de la producción, distribución, exhibición o publicación de los resultados del estudio, siempre y cuando se cumplan las condiciones de uso descritas anteriormente.
-		
+
 <table class="signature-block">
   <tr>
     <td>

--- a/_pages/resources/participant-agreement.md
+++ b/_pages/resources/participant-agreement.md
@@ -1,14 +1,14 @@
 ---
 title: Example Design Research Participant Agreement
 description: An example design research participant agreement
-layout: page
+layout: redirect
 permalink: /participant-agreement/
-
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md
 ---
 
-# Example Design Research Participant Agreement 
+# Example Design Research Participant Agreement
 
-English version | [Google Docs version](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit) 
+English version | [Google Docs version](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit)
 
 ---
 
@@ -17,13 +17,13 @@ This agreement relates to your participation in a study led by `<organization>` 
 ---
 
 - **You are not required to participate and may opt out at any time.** If at any point you no longer wish to participate, please inform the study moderator.
-- **You will not receive payment or compensation for your participation.** You agree to perform all duties associated with your participation in this study during the period of `<project start date>` &ndash; `<project end date>` gratuitously and without expectation of payment or any other form of compensation from the United States Government. You freely and voluntarily agree to waive any right, claim, or other recourse against `<organization>` relating to compensation for your participation in this study. Additionally, you agree to grant the United States Government with unlimited and unrestricted rights to use and reproduce all materials associated with your participation in this study. 
+- **You will not receive payment or compensation for your participation.** You agree to perform all duties associated with your participation in this study during the period of `<project start date>` &ndash; `<project end date>` gratuitously and without expectation of payment or any other form of compensation from the United States Government. You freely and voluntarily agree to waive any right, claim, or other recourse against `<organization>` relating to compensation for your participation in this study. Additionally, you agree to grant the United States Government with unlimited and unrestricted rights to use and reproduce all materials associated with your participation in this study.
 - **`<organization>` may record this study.** `<organization>` may make video, audio, photographic, and written recordings of this study. These records will be kept in a secure location and shared only with persons with a valid need to know.
 - **`<organization>` will take appropriate precautions to protect your privacy,** as explained in our [Privacy Act Statement](https://www.gsa.gov/portal/content/162010) and [Privacy Impact Assessment](https://www.gsa.gov/portal/content/102237). `<organization>` takes steps to remove  any unnecessary sensitive and personally identifiable information captured during this research.
 
 ---
 
-Privacy Act Notice: GSA is asking for your contact information so that we can decide if you are able to participate in design research studies. Your participation in a study is optional; nothing changes if you decline. By providing your contact information, you agree to receive follow-up communications about the study. 
+Privacy Act Notice: GSA is asking for your contact information so that we can decide if you are able to participate in design research studies. Your participation in a study is optional; nothing changes if you decline. By providing your contact information, you agree to receive follow-up communications about the study.
 
 GSA's design research is conducted in the spirit of Executive Order 13571, Section 2B, which directs agencies to “establish mechanisms to solicit customer feedback on government services and use such feedback regularly to make service improvements”. GSA's collection of contact information is authorized by the E-Government Act of 2002 (P.L. 107-347, 44 USC § 3501).
 

--- a/_pages/resources/privacy-act-notice.md
+++ b/_pages/resources/privacy-act-notice.md
@@ -1,9 +1,10 @@
 ---
-permalink: /resources/privacy-act-notice.md
-layout: post
+permalink: /resources/privacy-act-notice/
+layout: redirect
 title: Privacy Act Notice
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/privacy-act-notice.md
 ---
 
 # Privacy Act Notice
@@ -19,8 +20,8 @@ Please state:
 
 Example Privacy Act Statement for GSA Real Estate Exchange
 
->GSA is asking for your email address in order to contact you about your experience with this website. You are not required to provide your email address. Nothing about how you can use this site will change if you do not provide your email address. 
+>GSA is asking for your email address in order to contact you about your experience with this website. You are not required to provide your email address. Nothing about how you can use this site will change if you do not provide your email address.
 >
->This collection of information is authorized by the E-Government Act of 2002 (P.L. 107-347, 44 USC § 3501). GSA may use this information pursuant to its published Privacy Act system of records notice, GSA SORN PBS-5. 
+>This collection of information is authorized by the E-Government Act of 2002 (P.L. 107-347, 44 USC § 3501). GSA may use this information pursuant to its published Privacy Act system of records notice, GSA SORN PBS-5.
 >
 >Thank you for helping us improve this government website.

--- a/_pages/resources/research-alignment-workshop.md
+++ b/_pages/resources/research-alignment-workshop.md
@@ -1,22 +1,23 @@
 ---
 permalink: /research/alignment-workshop/
-layout: post
+layout: redirect
 title: Research alignment workshop
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md
 ---
 
 # Research alignment workshop
 
-As researchers, it's our role to collect *meaningful* information about our users and problem space so that our team can make better product decisions. To do this effectively, we must involve team members and stakeholders in the development of our initial research strategy. 
+As researchers, it's our role to collect *meaningful* information about our users and problem space so that our team can make better product decisions. To do this effectively, we must involve team members and stakeholders in the development of our initial research strategy.
 
-A research alignment workshop publicizes team questions and prioritizes research themes, setting you up to create a research plan that drives maximum value for your team. 
+A research alignment workshop publicizes team questions and prioritizes research themes, setting you up to create a research plan that drives maximum value for your team.
 
 
 ## What you'll need
 
 - [ ] 1 hour with all key stakeholders + 15 minutes of prep-work
-- [ ] A large room with plenty of white board space 
+- [ ] A large room with plenty of white board space
 - [ ] A dedicated note-taker (since you'll be playing the facilitator role, it's extremely helpful to have someone to help you document the session)
 - [ ] Post-it notes
 - [ ] Sharpies
@@ -24,80 +25,80 @@ A research alignment workshop publicizes team questions and prioritizes research
 - [ ] Dot voting stickers
 
 
-## Prep-work - 10-15 minutes 
+## Prep-work - 10-15 minutes
 
 In the workshop, participants (including you!) will be sharing their burning research questions with the team. Prior to the workshop day, have each team member spend 10-15 minutes on a short homework assignment to maximize the efficiency of your workshop and ensure that team members bring thoughtful questions to the session.  
 
-#### Assignment template 
+#### Assignment template
 
-> Over the next `[timeframe]` we'll be working together to `[key project objectives]`. I'm sure you have a ton of questions you'd like answered about `[key user groups]` and `[experience under study]`. To prepare for our Research Alignment Workshop on `[date]`, please take some time to document these questions. 
+> Over the next `[timeframe]` we'll be working together to `[key project objectives]`. I'm sure you have a ton of questions you'd like answered about `[key user groups]` and `[experience under study]`. To prepare for our Research Alignment Workshop on `[date]`, please take some time to document these questions.
 
 #### Instructions
 
 1. Set a timer for 5 minutes
 1. Brainstorm questions that you feel we need answered in order to create a successful *[feature, product, idea]*
-1. Select your top questions (3-5) and write them on sticky notes (1 question per sticky) 
+1. Select your top questions (3-5) and write them on sticky notes (1 question per sticky)
 1. Bring your top questions to the session
-1. Spend no more than 15 minutes on this activity! 
+1. Spend no more than 15 minutes on this activity!
 
-**Note:** Calendar blocking, slack reminders, and in-person reminders are all really effective ways to ensure that your team members complete their homework! 
+**Note:** Calendar blocking, slack reminders, and in-person reminders are all really effective ways to ensure that your team members complete their homework!
 
 
 ## Opening ~ 5 minutes
 
-Open with a brief discussion about the need for collaboration in the development of a solid research strategy (research success = team success). Then, spend a few minutes on the following: 
+Open with a brief discussion about the need for collaboration in the development of a solid research strategy (research success = team success). Then, spend a few minutes on the following:
 
 - **Discuss the workshop objectives:**
 	- Share and discuss key questions
 	- Align on most important research themes
-	- Prioritize research themes and determine study scope 
-- **Discuss mindset/participation expectations:** This is a collaborative activity that requires active participation and focus from all involved. 
+	- Prioritize research themes and determine study scope
+- **Discuss mindset/participation expectations:** This is a collaborative activity that requires active participation and focus from all involved.
 	- No e-mail
 	- Get ready to share
 	- ["Yes, and..."](https://en.wikipedia.org/wiki/Yes,_and...) the conversation
 
 ## Question Sharing ~ 25 minutes
 
-At this time, you'll ask the group to get out their post-it notes. Team members will each take a turn acting as the reader, while the rest of the group will act as the listeners. 
+At this time, you'll ask the group to get out their post-it notes. Team members will each take a turn acting as the reader, while the rest of the group will act as the listeners.
 
 **The reader:** Read the question out loud. Then, repeat it so the group can fully absorb the question.   
 
 **The listeners:** Discuss the question and its merits, Record offshoot questions.
 
-**The facilitator:** If necessary, probe the reader about the intent of their question. Keep in mind that people's questions may not reflect what they actually want to know. They may be leading or completely misdirected - it's your job to understand the spirit behind the question and work with the reader to rephrase their question, if necessary. 
+**The facilitator:** If necessary, probe the reader about the intent of their question. Keep in mind that people's questions may not reflect what they actually want to know. They may be leading or completely misdirected - it's your job to understand the spirit behind the question and work with the reader to rephrase their question, if necessary.
 
-**Example** 
+**Example**
 
-You're developing a mentorship tool to connect youth with adult mentors in a field of interest. 
+You're developing a mentorship tool to connect youth with adult mentors in a field of interest.
 
 > *Reader:* My question to our young users is, "How often do you meet with adults 1:1, in person?"
-> 
-> *Facilitator:* Interesting, what were your thoughts going into that question? 
-> 
-> *Reader:* Well, I'm asking because I think that in-person meetings are one of the ways to develop trust between two people and our tool should probably have some kind of 1:1 component. 
-> 
+>
+> *Facilitator:* Interesting, what were your thoughts going into that question?
+>
+> *Reader:* Well, I'm asking because I think that in-person meetings are one of the ways to develop trust between two people and our tool should probably have some kind of 1:1 component.
+>
 > *Facilitator:* It sounds like you're interested in is understanding how trust is formed between youths and adults.    
-> 
-> *Reader:* Yes, definitely. We should be able to create a trusting environment in our product. 
-> 
+>
+> *Reader:* Yes, definitely. We should be able to create a trusting environment in our product.
+>
 > *Facilitator:* Great, let's rephrase your question. On a new sticky note you can write, "What are drivers of trust in youth-adult relationships?"   
 
-In this example, our reader just needed some guidance to articulate their question. In this way, we have *empowered* the reader and given them *ownership* over their question. We have also turned the workshop into a learning activity for the entire group, providing them hands-on practice to create well-developed research questions (just some of the sneaky side benefits of the workshop). 
+In this example, our reader just needed some guidance to articulate their question. In this way, we have *empowered* the reader and given them *ownership* over their question. We have also turned the workshop into a learning activity for the entire group, providing them hands-on practice to create well-developed research questions (just some of the sneaky side benefits of the workshop).
 
-After a few people have shared,  you will start to see similar questions emerge. Continue to group post-its into themes as the activity progresses. Allow a few minutes for the group to share any new questions that were sparked while listening to their colleagues. Once you have all your questions on the board and grouped into themes, you can move onto the next phase of the activity. 
+After a few people have shared,  you will start to see similar questions emerge. Continue to group post-its into themes as the activity progresses. Allow a few minutes for the group to share any new questions that were sparked while listening to their colleagues. Once you have all your questions on the board and grouped into themes, you can move onto the next phase of the activity.
 
 
 ## Prioritization and Voting ~ 20 minutes
 
 > "You can do anything - but not everything" - David Allen
 
-Spend a few minutes reviewing your themes and naming them appropriately. Instruct the group that they will be voting on themes they feel would be of most value to the design process, since we won't be able to explore everything. 
+Spend a few minutes reviewing your themes and naming them appropriately. Instruct the group that they will be voting on themes they feel would be of most value to the design process, since we won't be able to explore everything.
 
-Give everyone 6 dot voting stickers and 3 votes - 3 for the highest priority, 2 for medium and 1 for lowest priority. 
+Give everyone 6 dot voting stickers and 3 votes - 3 for the highest priority, 2 for medium and 1 for lowest priority.
 
-Tally up the dots and prioritize your research scope. Depending on the length of your research phase and the resources available to you, you may choose multiple research themes to explore. 
+Tally up the dots and prioritize your research scope. Depending on the length of your research phase and the resources available to you, you may choose multiple research themes to explore.
 
-*Note:* Be direct and honest about the scope you will take on (and what you won't!), as you will be held accountable for delivering on these promises. 
+*Note:* Be direct and honest about the scope you will take on (and what you won't!), as you will be held accountable for delivering on these promises.
 
 
 ## After the workshop ~ 10 minutes
@@ -105,9 +106,9 @@ Tally up the dots and prioritize your research scope. Depending on the length of
 Immediately following the workshop, document everything! Record all key questions, themes and prioritization. Send a follow-up e-mail to your team reviewing the research scope you've committed to. You're now ready to begin the research planning phase!
 
 ## Additional workshop benefits
-- **Research education:** If facilitated correctly, the workshop also provides a practical lesson in developing good research questions. Ideally, team members walk away with a new appreciation for this skillset and will approach research with more thoughtful questions in the future! 
-- **Team ownership over research strategy:** The team has co-created the research strategy and is bought into the process. They now know which themes will be explored and understand what kind of data they can expect as a result of the research. This also increases the likelihood that they will engage with user interviews and data analysis. 
-- **Reduces research scope creep:** Because you've given the team an opportunity to voice their questions and concerns, you have reduced the chance for stakeholders to slip new questions into your discussion guides and surveys later on. 
+- **Research education:** If facilitated correctly, the workshop also provides a practical lesson in developing good research questions. Ideally, team members walk away with a new appreciation for this skillset and will approach research with more thoughtful questions in the future!
+- **Team ownership over research strategy:** The team has co-created the research strategy and is bought into the process. They now know which themes will be explored and understand what kind of data they can expect as a result of the research. This also increases the likelihood that they will engage with user interviews and data analysis.
+- **Reduces research scope creep:** Because you've given the team an opportunity to voice their questions and concerns, you have reduced the chance for stakeholders to slip new questions into your discussion guides and surveys later on.
 - **A documented process:** Capturing the meaningful conversations around scope allows you to confidently answer questions from stakeholders that may arise later on, such as,*"why didn't we explore [topic]"* or *"I thought we were going to ask users about [topic]"*
 
 ## Credit

--- a/_pages/resources/research-lead.md
+++ b/_pages/resources/research-lead.md
@@ -1,19 +1,20 @@
 ---
 permalink: /research/lead/
-layout: post
+layout: redirect
 title: Research lead
 sidenav: research
 sticky_sidenav: true
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md
 ---
 
 # Research lead (role description)
 
 While being mindful that [18F practices research as a team sport](https://github.com/18F/ux-guide/blob/master/_pages/research/basics.md), research leads should:
 
-- **Set the research agenda.** Determine the team’s research needs (for example, [inform its anticipated design decisions](https://medium.com/mule-design/dig-in-the-right-spot-6dc7af5a75e8) or [validate its riskiest assumptions](https://mvpworkshop.co/validate-riskiest-assumption/)), and propose right-sized studies to address them, highlighting cost and trade-offs. Identify allies who will advocate for research. If stakeholders exhibit resistance, identify the sources of that resistance and develop appropriate responses. 
+- **Set the research agenda.** Determine the team’s research needs (for example, [inform its anticipated design decisions](https://medium.com/mule-design/dig-in-the-right-spot-6dc7af5a75e8) or [validate its riskiest assumptions](https://mvpworkshop.co/validate-riskiest-assumption/)), and propose right-sized studies to address them, highlighting cost and trade-offs. Identify allies who will advocate for research. If stakeholders exhibit resistance, identify the sources of that resistance and develop appropriate responses.
 - **Educate others on the role, types, and methods of research.** Help the team understand the different types of research (foundational, generative, evaluative), and why specific research [methods](https://methods.18f.gov) apply. Explain how to employ specific methods. Facilitate [research retrospectives](https://18f.gsa.gov/2018/10/23/two-exercises-for-improving-design-research-through-reflective-practice/) to encourage reflective practice.
 - **Identify and recruit a diverse and representative group of people to participate in design research, and inform their consent.** Facilitate the creation of [behavioral audience segments](http://adaptivepath.org/uploads/documents/apr-007_taskbased.pdf) and setup repeatable participant recruiting processes. Help the team understand the importance of diversity in recruiting.
-- **Keep the team's research on track and on time.** Plan for and execute studies around shared goals with predictable scope. Incorporate asynchronous tasks like “homework”, diary studies, etc. to make the best use of everyone’s time. Encourage [collaborative research analysis](https://18f.gsa.gov/2018/02/06/getting-partners-on-board-with-research-findings/) and synthesis, and help the team manage transitions between learning and building. 
+- **Keep the team's research on track and on time.** Plan for and execute studies around shared goals with predictable scope. Incorporate asynchronous tasks like “homework”, diary studies, etc. to make the best use of everyone’s time. Encourage [collaborative research analysis](https://18f.gsa.gov/2018/02/06/getting-partners-on-board-with-research-findings/) and synthesis, and help the team manage transitions between learning and building.
 - **Maintain quality.** Identify and mitigate risks to quality design research, such as ethics, bias, and privacy and legal risk (for example, help the team understand how to conduct research that is Paperwork Reduction Act-compliant by design). Ensure rigor with [checklists](https://methods.18f.gov/interview-checklist/).
 - **Make research visible.** Inspire others to adopt a richer and more nuanced perspective of the people for whom they’re solving problems. Help people take findings back to the organization in a way that can be acted upon. Update project-level onboarding, knowledge management, etc. to reflect the research done to date.
 

--- a/_pages/resources/research-plan.md
+++ b/_pages/resources/research-plan.md
@@ -1,8 +1,8 @@
 ---
-layout: page
-permalink: /resources/research-plan/
-layout: post
 title: Research plan
+permalink: /resources/research-plan/
+layout: redirect
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md
 ---
 
 # Research plan
@@ -56,7 +56,7 @@ title: Research plan
 > Describe at a high-level [who should participate in this study](https://ux-guide.18f.gov/research/plan/#participants-and-recruiting), and how you’ll recruit them. Consider how the team will communicate with participants, for example [by email](https://ux-guide.18f.gov/resources/#email-templates) and how the team will get [informed consent](https://ux-guide.18f.gov/research/do/#getting-informed-consent) from participants. See the [legal section](https://ux-guide.18f.gov/research/legal/) of the UX Guide for more information.
 
 ## Ethics considerations
-> Document the [ethical principles or concerns](https://ux-guide.18f.gov/research/plan/#ethical-considerations) that influence this research approach. Discuss as a team the [biases](https://ux-guide.18f.gov/research/bias/) that could influence the work. 
+> Document the [ethical principles or concerns](https://ux-guide.18f.gov/research/plan/#ethical-considerations) that influence this research approach. Discuss as a team the [biases](https://ux-guide.18f.gov/research/bias/) that could influence the work.
 
 
 ## Expected outcomes

--- a/_pages/resources/rolling-issues-log.md
+++ b/_pages/resources/rolling-issues-log.md
@@ -1,8 +1,9 @@
 ---
 title: Rolling issues log
 description: An issue-tracking template for use while conducting usability testing
-layout: page
+layout: redirect
 permalink: /rolling-issues-log/
+redirect: https://methods.18f.gov/rolling-issues-log/
 ---
 
 <style type="text/css" media="print">

--- a/_pages/resources/usability-test-guide.md
+++ b/_pages/resources/usability-test-guide.md
@@ -1,8 +1,9 @@
 ---
 title: Usability Test Guide [Template]
 description: An example script for use while moderating a usability testing
-layout: page
+layout: redirect
 permalink: /usability-test-script/
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-guide.md
 ---
 
 # Usability Test Guide [Template]

--- a/_pages/resources/usability-test-quality-heuristics.md
+++ b/_pages/resources/usability-test-quality-heuristics.md
@@ -1,3 +1,11 @@
+---
+title: Usability Test Quality Heuristics
+description: A list of indicators to help you and your team determine if your usability test will produce useful results.
+layout: redirect
+permalink: /usability-test-quality-heuristics/
+redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md
+---
+
 # Usability test quality heuristics
 
 The following indicators can help determine if a usability test will produce useful results.  


### PR DESCRIPTION
Closes #245 
Closes #230 

[Preview](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/245-fix-broken-pages-display/)

The UX Guide has resources that currently display as markdown files in GitHub.
When search results send people to these pages, they appear to have no content because of the layout being used. While the UX team decides how these pages should in fact display, this PR fixes the issue by redirecting to the GitHub pages. (These are the links used in the site for these resources. See https://ux-guide.18f.gov/resources/ )

To test: 
1. Visit the resources links on the [Resources page](https://ux-guide.18f.gov/resources/)
2. On the GitHub page where you arrive from the link in step 1, copy the permalink at the top of the content
3. Back on the preview of the Guide, append the permalink text you copied to the site's home page url
Expected behavior: You should be redirected to the GitHub page