### PR TITLE
Recases and fixes link to content guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ subnav:
 
 ## What this guide is
 
-Like [our Content Guide](https://content-guide.18f.gov/how-to-use-this-guide/), the 18F UX guide is written for our internal designers, but we hope it’s a useful reference for anyone. Our working assumptions for this guide include that 18F UX designers are expected to possess, among other things:
+Like [our content guide](https://content-guide.18f.gov/), the 18F UX guide is written for our internal designers, but we hope it’s a useful reference for anyone. Our working assumptions for this guide include that 18F UX designers are expected to possess, among other things:
 
 * design research skills
 * the ability to skillfully navigate organizational relationships


### PR DESCRIPTION
[PREVIEW 🔗 ](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/preview/18f/ux-guide/minor-link-change/)
- The link to the content guide on the homepage is no longer valid.
  - The link redirects properly, but this PR directs the link to the homepage of the content guide.
- Recases `content guide` to lowercase for consistency with surrounding references to `UX guide`.