### PR TITLE
Change footer site url to correct address

### DIFF
--- a/_data/usa_anchor.yaml
+++ b/_data/usa_anchor.yaml
@@ -4,8 +4,8 @@
 anchor_data:
   - site_name: 18F UX Guide
     site_email: 18F@gsa.gov
-    site_url: https://ux-guide.18f.gsa.gov
-    site_about: https://ux-guide.18f.gsa.gov
+    site_url: https://ux-guide.18f.gov
+    site_about: https://ux-guide.18f.gov
     agency: U.S. General Services Administration
     agency_acronym: GSA
     agency_logo: gsa-logo-blue.svg

--- a/_data/usa_anchor.yaml
+++ b/_data/usa_anchor.yaml
@@ -4,8 +4,8 @@
 anchor_data:
   - site_name: 18F UX Guide
     site_email: 18F@gsa.gov
-    site_url: https://derisking-guide.18f.gsa.gov
-    site_about: https://derisking-guide.18f.gsa.gov
+    site_url: https://ux-guide.18f.gsa.gov
+    site_about: https://ux-guide.18f.gsa.gov
     agency: U.S. General Services Administration
     agency_acronym: GSA
     agency_logo: gsa-logo-blue.svg


### PR DESCRIPTION
This PR changes the configuration for the footer to point to the correct url for the ux-guide. The url does't seem to be pulled in by any component, but good to have the correct one set. 