### PR TITLE
Remove extra privacy policy url from identifier.

### DIFF
--- a/_includes/components/usa_identifier.html
+++ b/_includes/components/usa_identifier.html
@@ -53,7 +53,7 @@
           </li>
           <li class="usa-identifier__required-links-item">
             <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="Our privacy policy">
-              Privacy policy {{identifier.privacy_policy_url}}
+              Privacy policy
             </a>
           </li>
         </ul>


### PR DESCRIPTION
**What's wrong**
On the current site, the identifier (in the footer region) was showing the Privacy Policy URL to users. It shouldn't.
![image](https://user-images.githubusercontent.com/381122/184943023-fa70e097-113c-410a-b81f-c3c06698e406.png)


**What's changed in this PR**
I removed the URL that shouldn't appear after the words "Privacy Policy".
![image](https://user-images.githubusercontent.com/381122/184943451-3fc7d7a5-1afc-41c7-a138-bcad1cf092a1.png)
