### PR TITLE
Fixes presentations nav link on Resources

### DIFF
--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -14,7 +14,7 @@ subnav:
   - text: General
     href: "#general"
   - text: Presentations (GSA only)
-    href: "#presentations-gsa-only"
+    href: "#presentations"
   - text: Additional reading
     href: "#additional-reading"
 ---


### PR DESCRIPTION
I noticed the `Presentations (GSA only)` nav link on the [Resources page](https://ux-guide.18f.gov/resources/) is broken. 

This patch fixes the in-page link.