### PR TITLE
Remove site-wide meta description; add page-level meta descriptions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,10 +15,6 @@
 # in the templates via {{ site.myvariable }}.
 title: 18F User Experience Design Guide
 email: 18f-xd@gsa.gov
-description: >-
-  This is the beginning of a guide that will house
-  resources, norms, and practices for doing user
-  experience research and design work at 18F.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://ux-guide.18f.gov" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,6 +3,7 @@ layout: page
 permalink: /about/
 layout: post
 title: About this guide
+description: "How 18F user experience (UX) designers improve interactions between our government and the public"
 ---
 [//]: make it possible to put a class on a ul tag
 {::options parse_block_html="true" /}

--- a/_pages/design/build-a-prototype.md
+++ b/_pages/design/build-a-prototype.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Build a prototype
+description: "18F encourages building something that will help you answer your questions with the least investment."
 permalink: /design/build-a-prototype/
 sidenav: design
 sticky_sidenav: true

--- a/_pages/design/index.md
+++ b/_pages/design/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Design 
+description: "About prototypes and how they inform the work of 18F, as well as resources on web publishing platforms and design systems to help you get started."
 permalink: /design/
 layout: post
 sidenav: design

--- a/_pages/design/use-a-design-system.md
+++ b/_pages/design/use-a-design-system.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Use a design system
+description: "A design system can help your team prototype faster, scale, manage front-end design debt, and apply consistency across your applications."
 permalink: /design/use-a-design-system/
 sidenav: design
 sticky_sidenav: true

--- a/_pages/our-approach/defining-design.md
+++ b/_pages/our-approach/defining-design.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Defining design
+description: "18F user experience (UX) designers see design as a process of intentionally deciding, over and over, how interactions should work for users, based on research."
 permalink: /our-approach/defining-design/
 sidenav: our-approach
 sticky_sidenav: true

--- a/_pages/our-approach/index.md
+++ b/_pages/our-approach/index.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Our approach
+description: "Read about 18F's essential approach to our design practice."
 permalink: /our-approach/
 sidenav: our-approach
 sticky_sidenav: true

--- a/_pages/our-approach/meet-people-where-they-are.md
+++ b/_pages/our-approach/meet-people-where-they-are.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Meet partners where they are
+description: "18F user experience (UX) designers view government agency partners as co-creators, encouraging a more participatory and sustainable design process."
 permalink: /our-approach/meet-partners-where-they-are/
 sidenav: our-approach
 sticky_sidenav: true

--- a/_pages/our-approach/stay-lean.md
+++ b/_pages/our-approach/stay-lean.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Stay lean
+description: "18F user experience (UX) designers take a collaborative, incremental, and outcome-focused approach to our work."
 permalink: /our-approach/stay-lean/
 sidenav: our-approach
 sticky_sidenav: true

--- a/_pages/our-approach/values-and-principles.md
+++ b/_pages/our-approach/values-and-principles.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Values and principles
+description: "These are the fundamentals that guide our work as 18F user experience (UX) designers."
 permalink: /our-approach/values-and-principles/
 sidenav: our-approach
 sticky_sidenav: true

--- a/_pages/research/bias.md
+++ b/_pages/research/bias.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bias
+description: "These are 18F's starting points for proactively engaging with bias in the user research process."
 permalink: /research/bias/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/clarify-the-basics.md
+++ b/_pages/research/clarify-the-basics.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Clarify the basics
+description: "All 18F teams commit to continuous design research in order to make better decisions informed by end user perspectives."
 permalink: /research/clarify-the-basics/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Do
+description: "After planning, doing research involves engaging with previously agreed upon knowledge, participants, and data."
 permalink: /research/do/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/ethics.md
+++ b/_pages/research/ethics.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Ethics
+description: "The following ethical principles help guide 18F user experience (UX) designers through some of the choices that this work can present."
 permalink: /research/ethics/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/index.md
+++ b/_pages/research/index.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Research
+description: "Design research explores possibilities, tests assumptions, and reduces risk by actively and systematically engaging with the world."
 permalink: /research/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/legal.md
+++ b/_pages/research/legal.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Legal
+description: "18F designs our research to account for The Antideficiency Act and The Paperwork Reduction Act of 1995 (PRA), among other laws."
 permalink: /research/legal/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/make-research-actionable.md
+++ b/_pages/research/make-research-actionable.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Make research actionable
+description: "Analysis, synthesis, and sharing helps 18F user experience (UX) designers reflect on the data we’ve collected and determine a course of action."
 permalink: /research/make-research-actionable/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/plan.md
+++ b/_pages/research/plan.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Plan
+description: "Planning helps 18F teams adapt our approaches to the real world and ensures everyone's time is respected throughout the research process."
 permalink: /research/plan/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/research/privacy.md
+++ b/_pages/research/privacy.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Privacy
+description: "18F’s research practices are grounded in building and maintaining trust with research participants, a large part of which is protecting their privacy."
 permalink: /research/privacy/
 sidenav: research
 sticky_sidenav: true

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Resources
+description: "Additional templates, checklists, presentations, and other resources that 18F user experience (UX) designers use."
 permalink: /resources/
 sidenav: overview
 sticky_sidenav: true

--- a/_pages/resources/assisting-in-research.md
+++ b/_pages/resources/assisting-in-research.md
@@ -2,6 +2,7 @@
 permalink: /research/assist/
 layout: redirect
 title: Assisting in research
+description: "How to assist in user research at 18F."
 sidenav: research
 sticky_sidenav: true
 redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/assisting-in-research.md

--- a/_pages/resources/research-alignment-workshop.md
+++ b/_pages/resources/research-alignment-workshop.md
@@ -2,6 +2,7 @@
 permalink: /research/alignment-workshop/
 layout: redirect
 title: Research alignment workshop
+description: "Use this workshop to help you collect meaningful information about your users and problem space so that we can make better product decisions together."
 sidenav: research
 sticky_sidenav: true
 redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md

--- a/_pages/resources/research-lead.md
+++ b/_pages/resources/research-lead.md
@@ -2,6 +2,7 @@
 permalink: /research/lead/
 layout: redirect
 title: Research lead
+description: "What a research lead's roles and responsibilities are at 18F."
 sidenav: research
 sticky_sidenav: true
 redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md

--- a/_pages/resources/research-plan.md
+++ b/_pages/resources/research-plan.md
@@ -1,5 +1,6 @@
 ---
 title: Research plan
+description: "A high-level overview of questions, goals, roles, methods, and timelines for conducting research at 18F."
 permalink: /resources/research-plan/
 layout: redirect
 redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: About this guide
+description: "How 18F user experience (UX) designers improve interactions between our government and the public"
 permalink: /
 sidenav: overview
 sticky_sidenav: true


### PR DESCRIPTION
Closes #223 

### Notes

Following [Google’s own meta description best practices](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions), I tried to:
- keep them under 160 characters
- make them unique and specific to each page
- use keywords where appropriate, but keep them natural

I went back and forth on trying to make each description a complete sentence. Sometimes it fit, sometimes it didn’t. I'll leave it up to the reviewers on whether we should keep that consistent.

My understanding is that once the site-wide meta description is gone, if a page doesn't have a page-level description, then the description defaults to the beginning of the page content. 

Tagging @bpdesigns for review as product owner of the UX Guide