### PR TITLE
Publish all content in the repo to ux-guide.18f.gov instead of linking some pages to GitHub

### DIFF
--- a/_pages/research/clarify-the-basics.md
+++ b/_pages/research/clarify-the-basics.md
@@ -101,7 +101,7 @@ We prefer in-person research when we want to better understand the environment i
 ## Good practices
 
 {:.list-item--margin-bottom-extra}
-- **[Choose a research lead.](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md)** A research lead is the team member ultimately responsible for setting the research agenda, explaining the team’s methods, tracking the team’s progress, and ensuring research quality. (While the research lead is normally 18F staff at the start, we work with our partners to identify someone on their side before the engagement ends.)
+- **[Choose a research lead.]({{ site.baseurl }}/research/lead)** A research lead is the team member ultimately responsible for setting the research agenda, explaining the team’s methods, tracking the team’s progress, and ensuring research quality. (While the research lead is normally 18F staff at the start, we work with our partners to identify someone on their side before the engagement ends.)
 - **Discuss.** Discuss your research plan and interview guides. Debrief after each session. Make sure to include partners in these discussions, which will go a long way in [getting them on board with research findings](https://18f.gsa.gov/2018/02/06/getting-partners-on-board-with-research-findings/).
 - **Determine research questions as well as interview questions.** (They’re different.)
     - Example research question: _How do medical librarians find and make use of academic journal literature in answering questions for their patrons?_

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -278,7 +278,7 @@ Moderating a research session can be nuanced, but we encourage all team members 
 - Allow time for notetakers or observers to ask follow-up questions. Leave time for the interviewee to ask questions of the team as well.
 - If appropriate, ask if they know others who would be good for your team to talk to.
 
-While UX Designers heavily utilize interviews, we also use a variety of other methods. Tips for moderating other methods can be found in the [18F Method Cards](https://methods.18f.gov). We’ve also created a breakdown of [usability test quality heuristics](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-quality-heuristics.md) ([18F/GSA access only](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)). For Technology Transformation Services staff interested in developing additional methods, the [Research guild (#g-research, 18F/GSA access only](https://gsa-tts.slack.com/messages/g-research)) is a great place to find collaborators.
+While UX Designers heavily utilize interviews, we also use a variety of other methods. Tips for moderating other methods can be found in the [18F Method Cards](https://methods.18f.gov). We’ve also created a breakdown of [usability test quality heuristics]({{ site.baseurl }}/usability-test-quality-heuristics/) ([18F/GSA access only](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)). For Technology Transformation Services staff interested in developing additional methods, the [Research guild (#g-research, 18F/GSA access only](https://gsa-tts.slack.com/messages/g-research)) is a great place to find collaborators.
 
 ### Tips for remote research
 

--- a/_pages/research/do.md
+++ b/_pages/research/do.md
@@ -88,7 +88,7 @@ For sessions where you’ll interact with participants one-at-a-time, such as in
 - **Notetakers** document, usually word-for-word, what happens during the session. If you’re fortunate enough to have multiple notetakers, you might ask each notetaker to make notes about specific aspects of the session. For example, one notetaker might capture verbatim notes of what the participant says while another might capture what the participant does while interacting with a prototype.
 - **Observers** pay attention during the session, and ask questions when given time by the moderator
 
-Make time to meet with any team members who were not involved with designing the sessions but will help with research in order to explain the objectives of the research and review the structure of the sessions, session materials, etc. This helps observers contribute to the comfort level of the session and to correctly interpret interactions between moderators and participants. Consider passing along this one-pager about [assisting in research](https://github.com/18F/ux-guide/blob/master/_pages/resources/assisting-in-research.md) to people who are brand new to research.
+Make time to meet with any team members who were not involved with designing the sessions but will help with research in order to explain the objectives of the research and review the structure of the sessions, session materials, etc. This helps observers contribute to the comfort level of the session and to correctly interpret interactions between moderators and participants. Consider passing along this one-pager about [assisting in research]({{ site.baseurl }}/research/assist) to people who are brand new to research.
 
 ### Preparing a workshop
 
@@ -105,7 +105,7 @@ In evaluative research such as [usability testing](https://methods.18f.gov/valid
 {:.list-item--margin-bottom-extra}
 1. **Clarify the tasks your sessions will investigate.** Tasks are often included in artifacts such as personas or user stories. If your team doesn’t yet have those artifacts, ask them to identify “the most essential things that people need to do” relative to your research area of focus. Then pick the top two or three tasks the prototype will need to depict.
 2. **Prepare a scenario for each task.** Scenarios help your team create a more believable prototype; they also help moderators prepare research participants during the sessions themselves. If applicable, incorporate your scenarios into the guide you’ll use to moderate the session.
-[Example usability test guide.](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-guide.md) ([18F/GSA access only version.](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/)).
+[Example usability test guide.]({{ site.baseurl }}/usability-test-script) ([18F/GSA access only version.](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/)).
 3. **Discuss with your team how and when you’ll share the prototype** (for example, sharing a link to an online prototype or sending a document).
 
 Prototypes create dependencies in your research. When doing research involving prototypes, you will need to:
@@ -199,9 +199,9 @@ Getting informed consent ensures that:
 
 Copy and customize one of the participant agreements below to reflect your research design. This is the agreement you'll ask participants to sign before they participate.
 
-- [Example design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md)
+- [Example design research participant agreement]({{ site.baseurl }}/participant-agreement)
 <br /> ([18F/GSA access only version](https://docs.google.com/document/d/16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo/edit))
-- [Spanish version of participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md)
+- [Spanish version of participant agreement]({{ site.baseurl }}/participant-agreement-spanish)
 <br />  ([18F/GSA access only version](https://docs.google.com/forms/d/13ra4T0BVWbjSPBfOuNj8zVclU5J4TquX_tFbHUQWUpc/edit))
 
 Correspond with participants ahead of time to explain things that might otherwise get lost in the agreement-signing process. In the event that a participant has not signed an agreement ahead of the interview, obtain their verbal consent. In order to give their informed consent, participants need to understand:
@@ -223,8 +223,8 @@ You must also let participants know:
 
 There are two email templates available to help with participant correspondence:
 
-1. [Template for introducing yourself](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md)<br />([18F/GSA access only version](https://drive.google.com/open?id=1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg))
-2. [Template for passing along a participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md)<br /> ([18F/GSA access only version](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit))
+1. [Template for introducing yourself]({{ site.baseurl }}/resources/email-templates/researcher-introduces-themselves)<br />([18F/GSA access only version](https://drive.google.com/open?id=1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg))
+2. [Template for passing along a participant agreement]({{ site.baseurl }}/resources/email-templates/researcher-sends-agreement)<br /> ([18F/GSA access only version](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit))
 
 Remember to cover the information listed above. Ask participants if they have any questions. Ensure they don’t feel pressure to participate in ways that make them uncomfortable.
 
@@ -256,7 +256,7 @@ Also remember to:
     - Download and install any necessary software (eg. Zoom if you are using Zoom for your sessions)
 - If you conduct research sessions via Google Meet and initiate a screen recording, the video will be saved to the Google Drive of the person who created the meeting. A link to the video will be added to the calendar event after the meeting.
 
-Your agency partners can often assist in the scheduling process, particularly when setting up sessions with stakeholders. Don’t hesitate to ask them for help! You can provide them with a tailored version of this [email where stakeholder introduces researcher](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md). ([18F/GSA access only version ](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).
+Your agency partners can often assist in the scheduling process, particularly when setting up sessions with stakeholders. Don’t hesitate to ask them for help! You can provide them with a tailored version of this [email where stakeholder introduces researcher]({{ site.baseurl }}/resources/email-templates/stakeholder-introduces-researcher). ([18F/GSA access only version ](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).
 
 ## Moderating research sessions
 
@@ -269,7 +269,7 @@ Before each session, you should double-check:
 - Your primary documentation method
 - That you have a backup documentation method (such as a notepad and a pen)
 
-Moderating a research session can be nuanced, but we encourage all team members to be involved. Make sure participants are comfortable and that facilitators, notetakers, and other team members are prepared. We created [a checklist of best practices for interviews](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md). ([18F/GSA access only version](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)). The checklist includes:
+Moderating a research session can be nuanced, but we encourage all team members to be involved. Make sure participants are comfortable and that facilitators, notetakers, and other team members are prepared. We created [a checklist of best practices for interviews]({{ site.baseurl }}/interview-checklist). ([18F/GSA access only version](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)). The checklist includes:
 
 {:.list-item--margin-bottom-extra}
 - Keep an eye on the time. Decide beforehand which questions or activities you must cover and which ones you can cut if you run out of time.
@@ -373,7 +373,7 @@ Here are a few high-level things to capture in a debrief:
 - What new questions do we have?
 - Are there any new people we should talk to?
 
-You may want to use this [example interview debrief worksheet](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief-guide.md) ([18F/GSA access only](https://docs.google.com/document/d/1axCpR-pqdDIDRAAktlpbDEe1LbDCTZB7WxH6S4owIrU/edit?usp=sharing)); feel free to modify it to your team’s needs. When determining which team members to include, default to a more diverse group. If a team member wasn’t part of the session, their role can be focused on asking questions and documenting.
+You may want to use this [example interview debrief worksheet]({{ site.baseurl }}/interview-debrief) ([18F/GSA access only](https://docs.google.com/document/d/1axCpR-pqdDIDRAAktlpbDEe1LbDCTZB7WxH6S4owIrU/edit?usp=sharing)); feel free to modify it to your team’s needs. When determining which team members to include, default to a more diverse group. If a team member wasn’t part of the session, their role can be focused on asking questions and documenting.
 
 
 ## Additional reading

--- a/_pages/research/legal.md
+++ b/_pages/research/legal.md
@@ -23,7 +23,7 @@ subnav:
 
 ## Compensating research participants and participant agreements
 
-See the Guide's "Plan" page section: "[Compensating research participants]({{site.baseurl}}/research/plan/#compensating-research-participants)" for legal requirements. Ask participants for signed or verbal confirmation of [informed consent](site.baseurl}}/research/do/#getting-informed-consent): see the [design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md). The agreement can be accessed in both English and Spanish. If you will be compensating participants, replace the section on compensation with details of the amount and method of payment, and indicate that they will be compensated regardless of how much of the session they complete.
+See the Guide's "Plan" page section: "[Compensating research participants]({{site.baseurl}}/research/plan/#compensating-research-participants)" for legal requirements. Ask participants for signed or verbal confirmation of [informed consent]({{ site.baseurl }}/research/do/#getting-informed-consent): see the [design research participant agreement]({{ site.baseurl }}/participant-agreement). The agreement can be accessed in both English and Spanish. If you will be compensating participants, replace the section on compensation with details of the amount and method of payment, and indicate that they will be compensated regardless of how much of the session they complete.
 
 
 ## The Paperwork Reduction Act of 1995

--- a/_pages/research/make-research-actionable.md
+++ b/_pages/research/make-research-actionable.md
@@ -62,7 +62,7 @@ Before conducting shared analysis or synthesis, make sure that any quote could b
 
 ### Choosing methods
 
-Making meaning out of research can involve any number of different [methods](http://methods.18f.gov). The most basic method is writing a summary of what you found. Write a brief summary of the data you collected that, when read together with your [research plan](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md), documents the research itself: the questions you started with, how you went about answering them, what you learned, and why it matters. Aim for true and useful, rather than comprehensive.
+Making meaning out of research can involve any number of different [methods](http://methods.18f.gov). The most basic method is writing a summary of what you found. Write a brief summary of the data you collected that, when read together with your [research plan]({{ site.baseurl }}/resources/research-plan), documents the research itself: the questions you started with, how you went about answering them, what you learned, and why it matters. Aim for true and useful, rather than comprehensive.
 
 Outside of writing a summary, you should choose your methods based on the desired outputs and outcomes of your research. For example:
 

--- a/_pages/research/plan.md
+++ b/_pages/research/plan.md
@@ -41,7 +41,7 @@ A research plan (sometimes also called a research protocol), describes the desig
 - Ethics considerations
 - Outputs and outcomes
 
-18F maintains [a research plan template on GitHub](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md). ([18F/GSA access only](https://docs.google.com/document/d/1M3GP1JWW9mlZAAONklogurd8qXZLLgBqcKfU5HiS9h0/edit#heading=h.qjlo8a1jasd5)). Your research plans do not have to follow this template. What’s important is that you create a plan at all. Research planning helps you and your team:
+18F maintains [a research plan template on GitHub]({{ site.baseurl }}/resources/research-plan). ([18F/GSA access only](https://docs.google.com/document/d/1M3GP1JWW9mlZAAONklogurd8qXZLLgBqcKfU5HiS9h0/edit#heading=h.qjlo8a1jasd5)). Your research plans do not have to follow this template. What’s important is that you create a plan at all. Research planning helps you and your team:
 
 - Openly commit to learning more about the problem(s) at hand
 - Agree on which information is most useful for informing future decisions
@@ -71,7 +71,7 @@ What do you want to learn to make better evidence-based decisions? Research ques
 
 Consider holding a research alignment workshop to help stakeholders share and discuss what they’re interested in learning. Regardless of how you build alignment, focus on the value of obtaining useful information.
 
-- [Research alignment workshop plan](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md).  ([18F/GSA access only version](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#heading=h.aou5xt3rvfpf))
+- [Research alignment workshop plan]({{ site.baseurl }}/research/alignment-workshop).  ([18F/GSA access only version](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#heading=h.aou5xt3rvfpf))
 - [Research alignment presentation slides (18F/GSA access only](https://docs.google.com/presentation/d/16z-oauPeHeBeVxYS3TFRXGFld4uVUEsUjAFZ87fM_IE/edit#slide=id.g4c9bb7ecb1_0_4))
 
 ### Methods
@@ -220,7 +220,7 @@ Hold a meeting to bring the team — including your agency partners — together
 Create an agenda and invite anyone who has an interest in the team’s research. Depending on where you’re at in the design process, you might begin the meeting with level-setting excercises such as:
 
 - [Hopes and fears exercise](https://methods.18f.gov/discover/hopes-and-fears/)
-- [Research-alignment exercise](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md)
+- [Research-alignment exercise]({{ site.baseurl }}/research/alignment-workshop)
 - Creating provisional [personas](https://methods.18f.gov/decide/personas/) (that is, personas not based on research)
 
 Next, review and confirm elements listed in the research plan. It’s especially important to confirm:
@@ -261,7 +261,7 @@ Session documentation can take many forms. We often conduct research that may co
 {:.list-item--margin-bottom-extra}
 - What is the lightest-weight way to document your session and still capture the information you need to create your desired outputs, conduct shared [analysis]({{site.baseurl}}/research/make-research-actionable), etc.?
 - What type of documentation will your participants be most comfortable with (see [Privacy]({{site.baseurl}}/research/privacy))?
-- Did you ask your participants for [consent](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md) for this form of documentation?
+- Did you ask your participants for [consent]({{ site.baseurl }}/participant-agreement) for this form of documentation?
 
 ### Documentation methods
 

--- a/_pages/research/privacy.md
+++ b/_pages/research/privacy.md
@@ -32,7 +32,7 @@ Each piece of collected or stored PII increases the risk of privacy violations. 
 
 {:.list-item--margin-bottom-extra}
 - Collect PII only when it is both legally authorized and necessary
-- Present [Privacy Act Notices](https://github.com/18F/ux-guide/blob/master/_pages/resources/privacy-act-notice.md) whenever they collect PII (in order to allow for informed consent)
+- Present [Privacy Act Notices]({{ site.baseurl }}/resources/privacy-act-notice) whenever they collect PII (in order to allow for informed consent)
 - Protect agency-held PII against anticipated threats to security or integrity which could result in substantial harm, embarrassment, inconvenience, or unfairness to the participant.
 
 18F complies with the Privacy Act by following the information practices outlined in our [Privacy Impact Assessment for Design Research](https://www.gsa.gov/cdnstatic/20200401_-_Design_Research_PIA_for%20posting.pdf). The [TTS Research Guild](https://github.com/18F/g-research) works with the [GSA Privacy Office](https://www.gsa.gov/reference/gsa-privacy-program) to annually review this assessment.
@@ -45,11 +45,11 @@ Each piece of collected or stored PII increases the risk of privacy violations. 
 The following guidelines, drawn from our Privacy Impact Assessment for Design Research, help us build trust and protect privacy. This list isn’t exhaustive, but it’s a good place to start:
 
 {:.list-item--margin-bottom-extra}
-- Ask key stakeholders to [introduce you before conducting interviews](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md) with their team
-- Build rapport with research participants in advance of the research session — for example, [by emailing participants](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md) to see if they have any questions about the research, or briefly meeting with participants before the session begins to go over any logistical requirements
+- Ask key stakeholders to [introduce you before conducting interviews]({{ site.baseurl }}/resources/email-templates/stakeholder-introduces-researcher) with their team
+- Build rapport with research participants in advance of the research session — for example, [by emailing participants]({{ site.baseurl }}/resources/email-templates/researcher-sends-agreement) to see if they have any questions about the research, or briefly meeting with participants before the session begins to go over any logistical requirements
 - Whenever you collect PII, store it digitally on [GSA’s approved systems for PII](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) and actively remove access to PII from anyone not on your project team; and always place paper documents with PII in locked file cabinets
 - Store design research administrative data (for example, contact information collected during research participant recruiting) separate from study data (for example, recorded video of a usability test); share research-related records on a need-to-know basis
-- Collect the [informed consent]({{site.baseurl}}/research/do/#getting-informed-consent) of anyone who participates in moderated research; we generally do this with a [participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md)
+- Collect the [informed consent]({{site.baseurl}}/research/do/#getting-informed-consent) of anyone who participates in moderated research; we generally do this with a [participant agreement]({{ site.baseurl }}/participant-agreement)
 - When scheduling research sessions via Google calendar, set the event visibility to “Private” (since invitations include the participant’s name and email address)
 - Before using a website to collect data, read its Terms of service and Privacy policy. For example, monitoring forum traffic is a great way to learn about users, but our use of these systems must comply with applicable privacy policies.
 - Use pseudonyms or participant codes (for example, “Participant 1”) when naming recordings, transcribing audio files, and writing reports

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -26,10 +26,10 @@ As indicated below, some of these resources are available only to staff of GSA (
 
 ## Research
 
-[Research plan](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md). ([18F/GSA access only](https://docs.google.com/document/d/1M3GP1JWW9mlZAAONklogurd8qXZLLgBqcKfU5HiS9h0/edit#)).  
+[Research plan]({{ site.baseurl }}/resources/research-plan). ([18F/GSA access only](https://docs.google.com/document/d/1M3GP1JWW9mlZAAONklogurd8qXZLLgBqcKfU5HiS9h0/edit#)).  
 Prompts for planning research. Pairs well with our [research planning]({{site.baseurl}}/research/planning) article.
 
-[Research alignment workshop](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md). ([18F/GSA access only](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#)).  
+[Research alignment workshop]({{ site.baseurl }}/research/alignment-workshop). ([18F/GSA access only](https://docs.google.com/document/d/1NI_riUcrxaMaHihxzHOsr5Gr1n-FxAIqGZ5wzKt3wh4/edit#)).  
 A workshop template for publicizing team questions and prioritizing research themes, setting you up to create a research plan that drives maximum value for your team.
 
 [Usability test quality heuristics]({{ site.baseurl }}/usability-test-quality-heuristics). ([18F/GSA access only](https://docs.google.com/document/d/1qfGp3H1pdOlNbMYuJNQGyBIkpOcQErduDAl0adv1X-w/edit)).  
@@ -38,27 +38,27 @@ A list of indicators to help you and your team determine if your usability test 
 ### Privacy and informed consent
 18F’s Design Research is covered by [GSA's Privacy Act Statement for Design Research.](https://www.gsa.gov/reference/gsa-privacy-program/privacy-act-statement-for-design-research)
 
-[Privacy Act Notice Example](https://github.com/18F/ux-guide/blob/master/_pages/resources/privacy-act-notice.md). ([18F/GSA access only](https://docs.google.com/document/d/1CcVLPNNra1WCGqHewK2ojQ_ysHcGxmJ1IlsCo9pAiSU/edit#)).  
+[Privacy Act Notice Example]({{ site.baseurl }}/resources/privacy-act-notice). ([18F/GSA access only](https://docs.google.com/document/d/1CcVLPNNra1WCGqHewK2ojQ_ysHcGxmJ1IlsCo9pAiSU/edit#)).  
 Example of a statement to include in your participant agreement.  
 Please note: you should run substantial customizations by your supervisor, GSA’s Privacy Office, and GSA’s Office of General Counsel.  
 - [Legal notes from GSA OGC (18F/GSA access only](https://drive.google.com/a/gsa.gov/open?id=13FWBP5wMf_MgDToVBBrkOafFe5T8NsldzttGENhGgSU))
 - [GSA Privacy Impact Assessment for Design Research](https://www.gsa.gov/reference/gsa-privacy-program/privacy-impact-assessments-pia)
 
-[Design research participant agreement](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md). ([18F/GSA access only](https://drive.google.com/open?id=16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo)).  
-[Design research participant agreement in Spanish](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md).  
+[Design research participant agreement]({{ site.baseurl }}/participant-agreement). ([18F/GSA access only](https://drive.google.com/open?id=16qg58Hn92UlXLsi-2taizi7qe5mvQ3LMSkcvyHk8Bdo)).  
+[Design research participant agreement in Spanish]({{ site.baseurl }}/participant-agreement-spanish).  
 Example agreement for people participating in moderated design research.  
 Note: You can customize this template, but it must include a Privacy Act statement. If the interview is with a Federal employee, or otherwise will not include compensation, the agreement must also include an Anti-deficiency Act clause.
 
 Looking for PRA (Paperwork Reduction Act) information? See the [UX Guide Legal page]({{site.baseurl}}/research/legal).
 
 ### Interviews
-[Interview checklist](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md). ([18F/GSA access only](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)).  
+[Interview checklist]({{ site.baseurl }}/interview-checklist). ([18F/GSA access only](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)).  
 A checklist for planning and conducting in-depth interviews.
 
-[Interview guide](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-guide.md). ([18F/GSA access only](https://docs.google.com/document/d/1kju19eC5vjqAd6bZCprniLixr1_u1b4Qfs1zVwTn6UA/edit#)).  
+[Interview guide]({{ site.baseurl }}/interview-script). ([18F/GSA access only](https://docs.google.com/document/d/1kju19eC5vjqAd6bZCprniLixr1_u1b4Qfs1zVwTn6UA/edit#)).  
 An example guide for moderating in-depth interviews with users.
 
-[Interview debrief guide](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief-guide.md). ([18F/GSA access only](https://docs.google.com/document/d/1f5Ue2vbeg4-95EevvlURzvl6yMLwMOXtiNwe6OMnb9E/edit)).  
+[Interview debrief guide]({{ site.baseurl }}/interview-debrief). ([18F/GSA access only](https://docs.google.com/document/d/1f5Ue2vbeg4-95EevvlURzvl6yMLwMOXtiNwe6OMnb9E/edit)).  
 An example guide for teams leading a post-interview debrief.
 
 ### Findings presentation
@@ -67,13 +67,13 @@ A starting point for sharing what you learned during a path analysis or discover
 
 ## Email templates
 
-[Stakeholder introduces researcher](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md). ([18F/GSA access only](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).  
+[Stakeholder introduces researcher]({{ site.baseurl }}/resources/email-templates/stakeholder-introduces-researcher). ([18F/GSA access only](https://docs.google.com/document/d/1AEq-h3wuOxl8CCR9Gg4RPO7NaHJnedC4UbXN0UFQ24Y/edit)).  
 An email for stakeholders to introduce and legitimize 18F design researchers to their staff.
 
-[Researcher introduces themselves to a participant](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md). ([18F/GSA access only](https://docs.google.com/document/d/1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg/edit#)).  
+[Researcher introduces themselves to a participant]({{ site.baseurl }}/resources/email-templates/researcher-introduces-themselves). ([18F/GSA access only](https://docs.google.com/document/d/1aiK07pszR331v1d1J2tT6HUQ5JGsSjKjeFBzOwCwHLg/edit#)).  
 An email for introducing yourself to potential participants (for example, people who responded to your invitation to participate in the research) and finding a good time for them to participate in a moderated research session.
 
-[Researcher sends agreement to participant](https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md). ([18F/GSA access only](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit#)).  
+[Researcher sends agreement to participant]({{ site.baseurl }}/resources/email-templates/researcher-sends-agreement). ([18F/GSA access only](https://docs.google.com/document/d/1t01t_eLYWJXuKdJkhiyBqkWf4Yr5XsFAbNv-BDAZqzE/edit#)).  
 An email asking participants to review and sign a participant agreement before they participate in moderated research.
 
 ## Design

--- a/_pages/resources/assisting-in-research.md
+++ b/_pages/resources/assisting-in-research.md
@@ -1,23 +1,20 @@
 ---
 permalink: /research/assist/
-layout: redirect
+layout: post
 title: Assisting in research
 description: "How to assist in user research at 18F."
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/assisting-in-research.md
 ---
-
-# Assisting in research
 
 Thanks for offering to assist in research. At a high level, you will likely be expected to:
 
 - **Act as an observer:** Listen to the interview, usability test, etc. without interruption unless the research lead asks if you have questions to add.  
 - **Act as a notetaker:** Take verbatim notes as much you can. Don’t paraphrase. If it’s a remote test, turn off your microphone to mute the keyboard noises. If there is already a notetaker, it can be useful to take note of specific parts of the session. For example, during a usability test you might take note of the time it takes participants to complete specific tasks.
 
-Before the research begins, work with the [research lead](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md) to understand the research design and how you can best offer assistance:
+Before the research begins, work with the [research lead]({{ site.baseurl }}/research/lead) to understand the research design and how you can best offer assistance:
 
-1. Ask the research lead for a copy of the [research plan](https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md), [interview guide](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-script.md), and/or access to concepts (wireframes, prototypes, etc.) being tested
+1. Ask the research lead for a copy of the [research plan]({{ site.baseurl }}/resources/research-plan), [interview guide]({{ site.baseurl }}/interview-script), and/or access to concepts (wireframes, prototypes, etc.) being tested
 2. Review these materials, and note any questions
 3. Schedule a meeting with the research lead to run a practice session, and clarify any points of confusion
 

--- a/_pages/resources/email-templates/researcher-introduces-themselves.md
+++ b/_pages/resources/email-templates/researcher-introduces-themselves.md
@@ -1,5 +1,5 @@
 ---
-permalink: /resources/email-templates/researcher-introduces-themselves
+permalink: /resources/email-templates/researcher-introduces-themselves/
 layout: post
 title: Email template - Researcher introduces themselves to a participant
 sidenav: research

--- a/_pages/resources/email-templates/researcher-introduces-themselves.md
+++ b/_pages/resources/email-templates/researcher-introduces-themselves.md
@@ -1,10 +1,9 @@
 ---
 permalink: /resources/email-templates/researcher-introduces-themselves
-layout: redirect
+layout: post
 title: Email template - Researcher introduces themselves to a participant
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-introduces-themselves.md
 ---
 
 Hey `[Participant name]`,  

--- a/_pages/resources/email-templates/researcher-sends-agreement.md
+++ b/_pages/resources/email-templates/researcher-sends-agreement.md
@@ -1,10 +1,9 @@
 ---
 permalink: /resources/email-templates/researcher-sends-agreement
-layout: redirect
+layout: post
 title: Email template - Researcher sends agreement to a participant
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/researcher-sends-agreement.md
 ---
 
 Hey `[Participant name]`,  

--- a/_pages/resources/email-templates/researcher-sends-agreement.md
+++ b/_pages/resources/email-templates/researcher-sends-agreement.md
@@ -1,5 +1,5 @@
 ---
-permalink: /resources/email-templates/researcher-sends-agreement
+permalink: /resources/email-templates/researcher-sends-agreement/
 layout: post
 title: Email template - Researcher sends agreement to a participant
 sidenav: research

--- a/_pages/resources/email-templates/stakeholder-introduces-researcher.md
+++ b/_pages/resources/email-templates/stakeholder-introduces-researcher.md
@@ -1,10 +1,9 @@
 ---
 permalink: /resources/email-templates/stakeholder-introduces-researcher
-layout: redirect
+layout: post
 title: Email template - Stakeholder introduces researcher
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/email-templates/stakeholder-introduces-researcher.md
 ---
 
 Hi `[Colleagues]`,  

--- a/_pages/resources/email-templates/stakeholder-introduces-researcher.md
+++ b/_pages/resources/email-templates/stakeholder-introduces-researcher.md
@@ -1,5 +1,5 @@
 ---
-permalink: /resources/email-templates/stakeholder-introduces-researcher
+permalink: /resources/email-templates/stakeholder-introduces-researcher/
 layout: post
 title: Email template - Stakeholder introduces researcher
 sidenav: research

--- a/_pages/resources/interview-checklist.md
+++ b/_pages/resources/interview-checklist.md
@@ -1,12 +1,9 @@
 ---
 title: Interview checklist
 description: Helpful reminders for moderating interviews
-layout: redirect
+layout: post
 permalink: /interview-checklist/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md
 ---
-
-# Interview checklist
 
 [Interviews](https://methods.18f.gov/stakeholder-and-user-interviews/) often progress through key moments: introductions lead to warm-up questions, which lead to topic-specific questions, activities, etc. This checklist outlines those key moments, and suggests things to do as you go through them. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1zRA2EK9qZ5H_cM3Ki5xf6Gz72F6Ah6i0E87YpwHTC9A/edit)
 

--- a/_pages/resources/interview-checklist.md
+++ b/_pages/resources/interview-checklist.md
@@ -90,7 +90,7 @@ Once the interview is complete, **spend 15 minutes** completing a post-interview
 
 ### Make sure to
 - [ ] If you’ve recorded the interview: Move any recordings from your Google Drive to the project folder
-- [ ] Engage the team in a post-interview debrief ([example](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief.md)) to discuss surprises and reflect on what you heard
+- [ ] Engage the team in a post-interview debrief ([example]({{ site.baseurl }}/interview-debrief)) to discuss surprises and reflect on what you heard
 - [ ] Consider updating the interview guide based on this interview
 - [ ] If you promised the participant any follow-up communications, identify who will send them and when
 - [ ] Optional: Update your study contact list

--- a/_pages/resources/interview-debrief-guide.md
+++ b/_pages/resources/interview-debrief-guide.md
@@ -1,12 +1,9 @@
 ---
 title: Interview Debrief Guide [Template]
 description: An example worksheet to engage research teams in post-moderated research conversation
-layout: redirect
+layout: post
 permalink: /interview-debrief/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-debrief-guide.md
 ---
-
-# Interview Debrief Guide [Template]
 
 The following questions are provided as useful starting points for facilitating post-moderated research conversation (for example, after an [in-depth interview](https://methods.18f.gov/stakeholder-and-user-interviews/) or a [usability test](https://methods.18f.gov/usability-testing/)). We recommend copying the questions to collaborative writing tool and giving the team four minutes per section to respond, and then facilitating a section-wise discussion. GSA Staff, see this [Google Doc Template](https://docs.google.com/document/d/1f5Ue2vbeg4-95EevvlURzvl6yMLwMOXtiNwe6OMnb9E/edit#).
 

--- a/_pages/resources/interview-guide.md
+++ b/_pages/resources/interview-guide.md
@@ -1,12 +1,9 @@
 ---
 title: Interview guide [template]
 description: An example script for use while leading a user interview
-layout: redirect
+layout: post
 permalink: /interview-script/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-guide.md
 ---
-
-# Interview guide [template]
 
 This document includes example questions grouped along key moments often found in our in-depth interviews: introductions, warm-up, topic-specific questions, demos, etc. Edit these questions as you see fit. If your questions are specific or your participant’s time scarce, consider sharing some questions ahead of time. See [this checklist](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md) for running an in-depth interview. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1kju19eC5vjqAd6bZCprniLixr1_u1b4Qfs1zVwTn6UA/edit#)
 
@@ -55,7 +52,7 @@ What’s one thing you wish were more straightforward about `[topic]`?
 
 ## Demo
 
-_Note: If you’re running a usability test, consider this [example usability test script](https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-guide.md) instead._
+_Note: If you’re running a usability test, consider this [example usability test script]({{ site.baseurl }}/usability-test-script) instead._
 
 Thanks. Now I’m going to ask you to consider how you might respond to the following scenarios using this website. I’m going to read each scenario out loud, and I’ll also share the text of the scenario via chat.
 

--- a/_pages/resources/interview-guide.md
+++ b/_pages/resources/interview-guide.md
@@ -5,7 +5,7 @@ layout: post
 permalink: /interview-script/
 ---
 
-This document includes example questions grouped along key moments often found in our in-depth interviews: introductions, warm-up, topic-specific questions, demos, etc. Edit these questions as you see fit. If your questions are specific or your participant’s time scarce, consider sharing some questions ahead of time. See [this checklist](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md) for running an in-depth interview. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1kju19eC5vjqAd6bZCprniLixr1_u1b4Qfs1zVwTn6UA/edit#)
+This document includes example questions grouped along key moments often found in our in-depth interviews: introductions, warm-up, topic-specific questions, demos, etc. Edit these questions as you see fit. If your questions are specific or your participant’s time scarce, consider sharing some questions ahead of time. See [this checklist]({{ site.baseurl }}/interview-checklist) for running an in-depth interview. GSA Staff, please see this [Google Doc Template](https://docs.google.com/document/d/1kju19eC5vjqAd6bZCprniLixr1_u1b4Qfs1zVwTn6UA/edit#)
 
 ## Introduction
 

--- a/_pages/resources/participant-agreement-spanish.md
+++ b/_pages/resources/participant-agreement-spanish.md
@@ -1,15 +1,11 @@
 ---
-title: Example Design Research Participant Agreement — Spanish
+title: Ejemplo del acuerdo para participantes en un estudio de diseño
 description: An example design research participant agreement in Spanish
-layout: redirect
+layout: post
 permalink: /participant-agreement-spanish/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md
 ---
 
-# Ejemplo del acuerdo para participantes en un estudio de diseño
-### Spanish version
-
-### _([English version](/participant-agreement/))_
+[English version](/participant-agreement/)
 
 ---
 

--- a/_pages/resources/participant-agreement.md
+++ b/_pages/resources/participant-agreement.md
@@ -1,9 +1,8 @@
 ---
 title: Example Design Research Participant Agreement
 description: An example design research participant agreement
-layout: redirect
+layout: post
 permalink: /participant-agreement/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement.md
 ---
 
 ---
@@ -11,11 +10,9 @@ English version:
 - [Google Docs version with participant compensation](https://docs.google.com/document/d/18GLTggHUDI5MVrmL5Lbot58EB6c6tAkMbg54GqFaETc/edit)
 - [Google Docs version without participant compensation](https://docs.google.com/document/d/1EPElAVthOF2ojcoamRitDHSYK4lT9c5yFY8IBwbJNqE/edit)
 
-[Spanish version](https://github.com/18F/ux-guide/blob/master/_pages/resources/participant-agreement-spanish.md) (Note: Updates of the Spanish version pending translation of the updated English version.)
+[Spanish version]({{ site.baseurl }}/participant-agreement-spanish) (Note: Updates of the Spanish version pending translation of the updated English version.)
 
 ---
-
-# Example Design Research Participant Agreement (_without participant compensation_)
 
 This agreement relates to your participation in a U.S. General Services Administration (GSA) design research project. The project will take place between `<project start date>` and `<project end date>`. Our session with you is scheduled for `<session duration>`. The project’s purpose is to better understand `<area of inquiry>`. We ask that you read, sign, and return this agreement so you know your rights and what to expect from us. 
 

--- a/_pages/resources/privacy-act-notice.md
+++ b/_pages/resources/privacy-act-notice.md
@@ -1,13 +1,10 @@
 ---
 permalink: /resources/privacy-act-notice/
-layout: redirect
+layout: post
 title: Privacy Act Notice
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/privacy-act-notice.md
 ---
-
-# Privacy Act Notice
 
 The Privacy Act of 1974, 5 USC 552a, provides protection to individuals by ensuring that personal information collected by Federal agencies is limited to that which is legally authorized and necessary and is protected against anticipated threats to security or integrity which could result in substantial harm, embarrassment, inconvenience or unfairness to the individual. The Privacy Act also requires that Privacy Act Notices appear whenever GSA collects personally identifiable information (PII) from individuals in order to allow for informed consent.
 

--- a/_pages/resources/research-alignment-workshop.md
+++ b/_pages/resources/research-alignment-workshop.md
@@ -1,14 +1,11 @@
 ---
 permalink: /research/alignment-workshop/
-layout: redirect
+layout: post
 title: Research alignment workshop
 description: "Use this workshop to help you collect meaningful information about your users and problem space so that we can make better product decisions together."
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-alignment-workshop.md
 ---
-
-# Research alignment workshop
 
 As researchers, it's our role to collect *meaningful* information about our users and problem space so that our team can make better product decisions. To do this effectively, we must involve team members and stakeholders in the development of our initial research strategy.
 

--- a/_pages/resources/research-lead.md
+++ b/_pages/resources/research-lead.md
@@ -7,7 +7,7 @@ sidenav: research
 sticky_sidenav: true
 ---
 
-While being mindful that [18F practices research as a team sport](https://github.com/18F/ux-guide/blob/master/_pages/research/basics.md), research leads should:
+While being mindful that [18F practices research as a team sport]({{ site.baseurl }}/research/clarify-the-basics/), research leads should:
 
 - **Set the research agenda.** Determine the team’s research needs (for example, [inform its anticipated design decisions](https://medium.com/mule-design/dig-in-the-right-spot-6dc7af5a75e8) or [validate its riskiest assumptions](https://mvpworkshop.co/validate-riskiest-assumption/)), and propose right-sized studies to address them, highlighting cost and trade-offs. Identify allies who will advocate for research. If stakeholders exhibit resistance, identify the sources of that resistance and develop appropriate responses.
 - **Educate others on the role, types, and methods of research.** Help the team understand the different types of research (foundational, generative, evaluative), and why specific research [methods](https://methods.18f.gov) apply. Explain how to employ specific methods. Facilitate [research retrospectives](https://18f.gsa.gov/2018/10/23/two-exercises-for-improving-design-research-through-reflective-practice/) to encourage reflective practice.

--- a/_pages/resources/research-lead.md
+++ b/_pages/resources/research-lead.md
@@ -1,14 +1,11 @@
 ---
 permalink: /research/lead/
-layout: redirect
-title: Research lead
+layout: post
+title: Research lead (role description)
 description: "What a research lead's roles and responsibilities are at 18F."
 sidenav: research
 sticky_sidenav: true
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-lead.md
 ---
-
-# Research lead (role description)
 
 While being mindful that [18F practices research as a team sport](https://github.com/18F/ux-guide/blob/master/_pages/research/basics.md), research leads should:
 

--- a/_pages/resources/research-plan.md
+++ b/_pages/resources/research-plan.md
@@ -2,11 +2,8 @@
 title: Research plan
 description: "A high-level overview of questions, goals, roles, methods, and timelines for conducting research at 18F."
 permalink: /resources/research-plan/
-layout: redirect
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/research-plan.md
+layout: post
 ---
-
-# Research plan
 
 ## Background
 

--- a/_pages/resources/usability-test-guide.md
+++ b/_pages/resources/usability-test-guide.md
@@ -1,14 +1,11 @@
 ---
 title: Usability Test Guide [Template]
 description: An example script for use while moderating a usability testing
-layout: redirect
+layout: post
 permalink: /usability-test-script/
-redirect: https://github.com/18F/ux-guide/blob/master/_pages/resources/usability-test-guide.md
 ---
 
-# Usability Test Guide [Template]
-
-This document provides example questions grouped along the key moments usually found in a usability test: introductions, warm up, task completion, follow up, and wrap up. If your participant’s time is scarce, consider sharing a few questions ahead of time. See also this [checklist for running an interview](https://github.com/18F/ux-guide/blob/master/_pages/resources/interview-checklist.md). GSA staff, please see this [Google Doc Template](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/edit#).
+This document provides example questions grouped along the key moments usually found in a usability test: introductions, warm up, task completion, follow up, and wrap up. If your participant’s time is scarce, consider sharing a few questions ahead of time. See also this [checklist for running an interview]({{ site.baseurl }}/interview-checklist). GSA staff, please see this [Google Doc Template](https://docs.google.com/document/d/1VimyVSt7qK3iKc2uZkobLWM0zuJuvO03vFk_R_EjhOU/edit#).
 
 ## Introduction
 


### PR DESCRIPTION
The following pages previously redirected to GitHub and are now pages in the UX guide itself:

- assisting-in-research
- interview-checklist
- interview-debrief-guide
- interview-guide
- participant-agreement-spanish
- participant-agreement
- privacy-act-notice
- research-alignment-workshop
- research-lead
- research-plan
- usability-test-guide
- researcher-introduces-themselves
- researcher-sends-agreement
- stakeholder-introduces-researcher

Links elsewhere in the guide that were pointing at the GitHub pages have been modified to point to the guide pages instead.

Closes #300 