### PR TITLE
Synchronize labels from the Methods repo

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,16 @@
+name: Sync labels from Methods repo
+
+on:
+  schedule:
+    # daily at 3am UTC so as to probably not disrupt anyone
+    - cron: '0 3 * * *'
+
+jobs:
+  labels:
+    name: synchronize labels from Methods repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: sync labels from Methods repo
+        uses: EndBug/label-sync@v2
+        with:
+          source-repo: 18F/methods


### PR DESCRIPTION
This PR adds a nightly GitHub action to synchronize the labels from [the Methods repo](/18f/methods) into this repo.

- any labels that exist in Methods but not here will be added here
- any labels that exist in both:
  - will take on the capitalization used in Methods
  - will take on the description used in Methods
  - will take on the color used in Methods
- any labels that exist ***only*** in this repo will be left alone

Requesting review from:
- @echappen: the codey bits; input/agreement with the above process
- @MelissaBraxton: input/agreement with the above process
- @bpdesigns: input/agreement with the above process