### PR TITLE
Remove preview link from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
 # 18F UX Guide
 
-18F user experience (UX) designers join cross-functional teams to collaboratively improve user experiences across government. This guide is here to help us get the job done. It’s neither a step-by-step tutorial nor a set of rules. Instead, it’s a starting point for 18F-led UX design: doing it, discussing it, and ensuring it’s done to a consistent level of quality. This guide is iterative and you can review [our goals](https://github.com/18F/ux-guide/wiki/Goals), [preview the site on Federalist](https://federalist-48b3228b-0241-4802-9442-e08ff5c3e680.app.cloud.gov/site/18f/ux-guide/), [contribute](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md) or get a general overview below.
+18F user experience (UX) designers join cross-functional teams to
+collaboratively improve user experiences across government. This guide is here
+to help us get the job done. It’s neither a step-by-step tutorial nor a set of
+rules. Instead, it’s a starting point for 18F-led UX design: doing it,
+discussing it, and ensuring it’s done to a consistent level of quality. This
+guide is iterative and you can review
+[our goals](https://github.com/18F/ux-guide/wiki/Goals),
+[contribute](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md) or get a
+general overview below.
 
 ---
 
 ## Table of contents
 
-1. [About](https://github.com/18F/ux-guide/blob/master/_pages/about.md)
+1. [About](https://github.com/18F/ux-guide/blob/main/_pages/about.md)
 1. Our approach
-    1. [Values and principles](https://github.com/18F/ux-guide/blob/master/_pages/our-approach/values-and-principles.md)
-    1. [Defining design](https://github.com/18F/ux-guide/blob/master/_pages/our-approach/defining-design.md)
-    1. [Stay lean](https://github.com/18F/ux-guide/blob/master/_pages/our-approach/stay-lean.md)
-    1. [Meet partners where they are](https://github.com/18F/ux-guide/blob/master/_pages/our-approach/meet-people-where-they-are.md)
+    1. [Values and principles](https://github.com/18F/ux-guide/blob/main/_pages/our-approach/values-and-principles.md)
+    1. [Defining design](https://github.com/18F/ux-guide/blob/main/_pages/our-approach/defining-design.md)
+    1. [Stay lean](https://github.com/18F/ux-guide/blob/main/_pages/our-approach/stay-lean.md)
+    1. [Meet partners where they are](https://github.com/18F/ux-guide/blob/main/_pages/our-approach/meet-people-where-they-are.md)
 1. Research
-    1. [Clarify the basics](https://github.com/18F/ux-guide/blob/master/_pages/research/clarify-the-basics.md)
-    1. [Plan](https://github.com/18F/ux-guide/blob/master/_pages/research/plan.md)
-    1. [Do](https://github.com/18F/ux-guide/blob/master/_pages/research/do.md)
-    1. [Make research actionable](https://github.com/18F/ux-guide/blob/master/_pages/research/make-research-actionable.md)
-    1. [Legal](https://github.com/18F/ux-guide/blob/master/_pages/research/legal.md)
-    1. [Privacy](https://github.com/18F/ux-guide/blob/master/_pages/research/privacy.md)
-    1. [Bias](https://github.com/18F/ux-guide/blob/master/_pages/research/bias.md)
-    1. [Ethics](https://github.com/18F/ux-guide/blob/master/_pages/research/ethics.md)
+    1. [Clarify the basics](https://github.com/18F/ux-guide/blob/main/_pages/research/clarify-the-basics.md)
+    1. [Plan](https://github.com/18F/ux-guide/blob/main/_pages/research/plan.md)
+    1. [Do](https://github.com/18F/ux-guide/blob/main/_pages/research/do.md)
+    1. [Make research actionable](https://github.com/18F/ux-guide/blob/main/_pages/research/make-research-actionable.md)
+    1. [Legal](https://github.com/18F/ux-guide/blob/main/_pages/research/legal.md)
+    1. [Privacy](https://github.com/18F/ux-guide/blob/main/_pages/research/privacy.md)
+    1. [Bias](https://github.com/18F/ux-guide/blob/main/_pages/research/bias.md)
+    1. [Ethics](https://github.com/18F/ux-guide/blob/main/_pages/research/ethics.md)
 1. Design 
-    1. [Build a prototype](https://github.com/18F/ux-guide/blob/master/_pages/design/build-a-prototype.md)
-    1. [Use a design system](https://github.com/18F/ux-guide/blob/master/_pages/design/use-a-design-system.md)
+    1. [Build a prototype](https://github.com/18F/ux-guide/blob/main/_pages/design/build-a-prototype.md)
+    1. [Use a design system](https://github.com/18F/ux-guide/blob/main/_pages/design/use-a-design-system.md)
 1. Resources
 
 ## Development

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -44,7 +44,7 @@ This guide is divided into three sections:
 
 
 
-If you have any suggestions or want to get involved, read [our contributing page](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md#non-18F-contributors); find us on our TTS Slack in either #ux, #ux-guide, or #g-research; or [create an issue in GitHub](https://github.com/18F/ux-guide/issues).
+If you have any suggestions or want to get involved, read [our contributing page](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md#non-18F-contributors); find us on our TTS Slack in either #ux, #ux-guide, or #g-research; or [create an issue in GitHub](https://github.com/18F/ux-guide/issues).
 
 
 ## Reusing this guide in other organizations
@@ -53,7 +53,7 @@ As a work of the federal government, this project is in the public domain within
 
 This guide is written for internal use and is shared in the spirit of open source.  This guide is a product of what we’ve learned from doing UX research and design in government over the past few years, in collaboration with GSA’s Office of General Counsel, Privacy Office, PRA (Paperwork Reduction Act) Desk Officer, and our partners within GSA and throughout other agencies.
 
-Feel free to [fork this guide](https://help.github.com/articles/fork-a-repo/) on GitHub and personalize it for your organization; we trust you’ll change it in whatever ways are best for you. If you have a suggestion, spot an error, or otherwise want to make constructive contribution to this guide, head over to [our contributing page](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md#non-18F-contributors).
+Feel free to [fork this guide](https://help.github.com/articles/fork-a-repo/) on GitHub and personalize it for your organization; we trust you’ll change it in whatever ways are best for you. If you have a suggestion, spot an error, or otherwise want to make constructive contribution to this guide, head over to [our contributing page](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md#non-18F-contributors).
 
 ## References
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -20,7 +20,7 @@ subnav:
     href: "#additional-reading"
 ---
 
-We’ve collected the following templates, presentations, checklists, etc. as starting points — feel free to [contribute to this guide](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md) and help us keep this list up-to-date!
+We’ve collected the following templates, presentations, checklists, etc. as starting points — feel free to [contribute to this guide](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md) and help us keep this list up-to-date!
 
 As indicated below, some of these resources are available only to staff of GSA (General Services Administration) or TTS (Technology Transformation Services).
 

--- a/index.md
+++ b/index.md
@@ -52,7 +52,7 @@ This guide is divided into three sections:
 
 
 
-If you have any suggestions or want to get involved, read [our contributing page](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md#non-18F-contributors); find us on Slack in either #ux, #ux-guide, or #g-research; or [create an issue in GitHub](https://github.com/18F/ux-guide/issues).
+If you have any suggestions or want to get involved, read [our contributing page](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md#non-18F-contributors); find us on Slack in either #ux, #ux-guide, or #g-research; or [create an issue in GitHub](https://github.com/18F/ux-guide/issues).
 
 
 ## Reusing this guide in other organizations
@@ -61,7 +61,7 @@ As a work of the federal government, this project is in the public domain within
 
 This guide is written for internal use and is shared in the spirit of open source.  This guide is a product of what we’ve learned from doing UX research and design in government over the past few years, in collaboration with GSA’s Office of General Counsel, Privacy Office, PRA (Paperwork Reduction Act) Desk Officer, and our agency partners.
 
-Feel free to [fork this guide](https://help.github.com/articles/fork-a-repo/) on GitHub and personalize it for your organization; we trust you’ll change it in whatever ways best suit you. Also, if you have a suggestion, spot an error, or otherwise want to make constructive contribution to this guide, head over to [our contributing page](https://github.com/18F/ux-guide/blob/master/CONTRIBUTING.md#non-18F-contributors).
+Feel free to [fork this guide](https://help.github.com/articles/fork-a-repo/) on GitHub and personalize it for your organization; we trust you’ll change it in whatever ways best suit you. Also, if you have a suggestion, spot an error, or otherwise want to make constructive contribution to this guide, head over to [our contributing page](https://github.com/18F/ux-guide/blob/main/CONTRIBUTING.md#non-18F-contributors).
 
 ## References
 
@@ -97,8 +97,8 @@ This guide draws on information from many resources. GSA cannot endorse these re
 ## Introduction
 
 - [About this guide]({{site.baseurl}}/about/)
-- [License](https://github.com/18F/ux-guide/blob/master/LICENSE.md)
-- [Resources](https://github.com/18F/ux-guide/tree/master/_pages/resources)
+- [License](https://github.com/18F/ux-guide/blob/main/LICENSE.md)
+- [Resources](https://github.com/18F/ux-guide/tree/main/_pages/resources)
 
 ## [Our Approach]({{site.baseurl}}/our-approach/)
 


### PR DESCRIPTION
* The preview link in the README was badly outdated and would only get more outdated over time. Preview links from Cloud.gov Pages/Federalist should be based on branches/pull requests, and any given preview link should be considered invalid once it is merged into the main branch.
* This PR also updates several links that pointed to the `master` branch. That branch was renamed to `main` a while back. The links still worked because GitHub automatically redirects them, but we might as well make them proper.

closes #186