### PR TITLE
Identify external links with an icon

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -1,3 +1,10 @@
+---
+---
+
+// ^ that up there is frontmatter tags so that Jekyll will process this file and
+// replace {{ site.baseurl }} correctly. Without the frontmatter tags, Jekyll
+// copies the file unedited.
+
 document.addEventListener('DOMContentLoaded', function() {
   PrivateEye({
     defaultMessage: "This link is private to GSA.",
@@ -33,4 +40,19 @@ document.addEventListener('DOMContentLoaded', function() {
       'tock.18f.gov'
     ]
   });
+
+  const externalLinkIcon = document.createElement("img");
+  externalLinkIcon.setAttribute(
+    "src",
+    `{{ site.baseurl }}/assets/uswds/img/usa-icons/launch.svg`
+  );
+  externalLinkIcon.setAttribute("style", "width: 1rem;");
+
+  Array.from(document.querySelectorAll("a[href]"))
+    .filter((a) => {
+      const href = a.getAttribute("href");
+      return !href.startsWith(window.location.origin) && !/^[/#]/.test(a.getAttribute("href"))
+    })
+    .forEach((a) => a.appendChild(externalLinkIcon.cloneNode()));
+
 }, false );


### PR DESCRIPTION
This pull request adds a small bit of client-side Javascript that is loaded on every page. This Javascript runs when the page is loaded and finds all `<a>` elements on the page that have a `href` attribute. For any of those elements where the `href` does not begin with `/`, `#`, or the same domain as the page itself, the Javascript will add the USWDS "launch" icon to the element text.

This is complimentary to PR #329 and addresses issue #297.

Review request:
- @lauraGgit: The Javascript to ensure it's reasonable, maintainable code
- @MelissaBraxton: The result to verify that it's identifying mostly the right links (I think checking every link on the site would be asking entirely too much 😂)