### PR TITLE
Add alt tag to external link icon

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -5,54 +5,61 @@
 // replace {{ site.baseurl }} correctly. Without the frontmatter tags, Jekyll
 // copies the file unedited.
 
-document.addEventListener('DOMContentLoaded', function() {
-  PrivateEye({
-    defaultMessage: "This link is private to GSA.",
-    ignoreUrls: [
-      'gsa-tts.slack.com',
-      'anywhere.gsa.gov',
-      'bookit.gsa.gov',
-      'calendar.gsa.gov',
-      'connect.gsa.gov',
-      'docs.google.com',
-      'drive.google.com',
-      'ea.gsa.gov',
-      'email.gsa.gov',
-      'gcims.gsa.gov',
-      'github.com/18F/Accessibility_Reviews',
-      'github.com/18F/blog-drafts',
-      'github.com/18F/codereviews',
-      'github.com/18F/DevOps',
-      'github.com/18F/Infrastructure',
-      'github.com/18F/security-incidents',
-      'github.com/18F/staffing-and-resources',
-      'github.com/18F/team-api.18f.gov',
-      'github.com/18F/writing-lab',
-      'gkey.gsa.gov',
-      'gsa-tts.slack.com',
-      'gsa.my.salesforce.com',
-      'gsaolu.gsa.gov',
-      'hrprod.hr.gsa.gov',
-      'insite.gsa.gov',
-      'mail.gsa.gov',
-      'meet.gsa.gov',
-      'pages-internal.18f.gov',
-      'tock.18f.gov'
-    ]
-  });
+document.addEventListener(
+  "DOMContentLoaded",
+  function () {
+    PrivateEye({
+      defaultMessage: "This link is private to GSA.",
+      ignoreUrls: [
+        "gsa-tts.slack.com",
+        "anywhere.gsa.gov",
+        "bookit.gsa.gov",
+        "calendar.gsa.gov",
+        "connect.gsa.gov",
+        "docs.google.com",
+        "drive.google.com",
+        "ea.gsa.gov",
+        "email.gsa.gov",
+        "gcims.gsa.gov",
+        "github.com/18F/Accessibility_Reviews",
+        "github.com/18F/blog-drafts",
+        "github.com/18F/codereviews",
+        "github.com/18F/DevOps",
+        "github.com/18F/Infrastructure",
+        "github.com/18F/security-incidents",
+        "github.com/18F/staffing-and-resources",
+        "github.com/18F/team-api.18f.gov",
+        "github.com/18F/writing-lab",
+        "gkey.gsa.gov",
+        "gsa-tts.slack.com",
+        "gsa.my.salesforce.com",
+        "gsaolu.gsa.gov",
+        "hrprod.hr.gsa.gov",
+        "insite.gsa.gov",
+        "mail.gsa.gov",
+        "meet.gsa.gov",
+        "pages-internal.18f.gov",
+        "tock.18f.gov",
+      ],
+    });
 
-  const externalLinkIcon = document.createElement("img");
-  externalLinkIcon.setAttribute(
-    "src",
-    `{{ site.baseurl }}/assets/uswds/img/usa-icons/launch.svg`
-  );
-  externalLinkIcon.setAttribute("style", "width: 1rem;");
+    const externalLinkIcon = document.createElement("img");
+    externalLinkIcon.setAttribute(
+      "src",
+      `{{ site.baseurl }}/assets/uswds/img/usa-icons/launch.svg`
+    );
+    externalLinkIcon.setAttribute("alt", "(external link)");
+    externalLinkIcon.setAttribute("style", "width: 1rem;");
 
-  Array.from(document.querySelectorAll("a[href]"))
-    .filter((a) => {
-      const href = a.getAttribute("href");
-      return !href.startsWith(window.location.origin) && !/^[/#]/.test(a.getAttribute("href"))
-    })
-    .forEach((a) => a.appendChild(externalLinkIcon.cloneNode()));
-
-}, false );
+    Array.from(document.querySelectorAll("a[href]"))
+      .filter((a) => {
+        const href = a.getAttribute("href");
+        return (
+          !href.startsWith(window.location.origin) &&
+          !/^[/#]/.test(a.getAttribute("href"))
+        );
+      })
+      .forEach((a) => a.appendChild(externalLinkIcon.cloneNode()));
+  },
+  false
+);


### PR DESCRIPTION
This PR adds the alt text `(external link)` to the external link `launch` icon. In VoiceOver on Mac, it reads these links as (for example) "link; our content guide; external link". I don't know if this is preferred for screenreader users, or if users tend to ask for the target URL before clicking, but it provides the same information that we were making available visually.

Addresses #338

Review request:
- @jstrothman and @claireb-gsa: review of the approach, or feedback if we should try something else