### PR TITLE
Do not add external link icons to links outside of the main content

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -51,7 +51,7 @@ document.addEventListener(
     externalLinkIcon.setAttribute("alt", "(external link)");
     externalLinkIcon.setAttribute("style", "width: 1rem;");
 
-    Array.from(document.querySelectorAll("a[href]"))
+    Array.from(document.querySelectorAll("main a[href]"))
       .filter((a) => {
         const href = a.getAttribute("href");
         return (


### PR DESCRIPTION
Previously all links on a page were scanned to check for external links and all external links were marked, which included links in the footer. This PR modifies that behavior so that only links in the `<main>` content area are checked and marked, and leaves footer links untouched.

* Closes #339 