### PR TITLE
Immediately sync labels

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,10 +1,23 @@
-name: pull request
+name: invalid links check
 
 on: [pull_request]
 
 jobs:
-  check-links:
-    name: verify links
+  root-relative-links-pages:
+    name: no root-relative links in source
+    runs-on: ubuntu-latest
+    env:
+      LANG: C.UTF-8
+    steps:
+      - uses: actions/checkout@v3
+      - name: check that root-relative internal links are prefixed (pages)
+        uses: mgwalker/action-no-root-relative-links@v1
+        with:
+          path: _pages
+          message: Internal link begins with /, but should begin with {{ site.baseurl }}/
+
+  internal-links:
+    name: verify internal links are valid
     runs-on: ubuntu-latest
     env:
       LANG: C.UTF-8
@@ -14,11 +27,6 @@ jobs:
         with:
           ruby-version: 2.7
           bundler-cache: true
-      - name: check that root-relative internal links are prefixed
-        uses: mgwalker/action-no-root-relative-links@v1
-        with:
-          path: _pages
-          message: Internal link begins with /, but should begin with {{ site.baseurl }}/
       - name: build the site
         run: bundle exec jekyll build
       - name: check for broken links

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,16 +1,13 @@
-name: Sync labels from Methods repo
+name: Sync labels
 
-on:
-  schedule:
-    # daily at 3am UTC so as to probably not disrupt anyone
-    - cron: '0 3 * * *'
+on: [label]
 
 jobs:
   labels:
-    name: synchronize labels from Methods repo
+    name: synchronize labels between repos
     runs-on: ubuntu-latest
     steps:
-      - name: sync labels from Methods repo
+      - name: sync labels between repos
         uses: EndBug/label-sync@v2
         with:
           source-repo: 18F/methods


### PR DESCRIPTION
A counterpart to [methods/#604](https://github.com/18F/methods/pull/604). When a label is created, modified, or deleted from this repo, immediately update the methods repo as well.