### PR TITLE
Sync labels on a schedule

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,6 +1,9 @@
 name: Sync labels
 
-on: [label]
+on:
+ schedule:
+   # daily at 3am UTC so as to probably not disrupt anyone
+   - cron: '0 3 * * *'
 
 jobs:
   labels:


### PR DESCRIPTION
There was a recent PR that attempted to cause labels to sync as soon as they were created/updated/deleted. However, the action we use to sync labels does not ***push*** labels, it only pulls them. So when a label is created in repo A, repo A would pull from repo B. Repo B does not get a notification that repo A has a new label and repo B does not get synced.

This PR reverts back to the scheduled label sync for now.