### PR TITLE
Add milestone syncing

### DIFF
--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -28,5 +28,5 @@ jobs:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const milestones = await github.paginate(`GET /repos/${ owner }/${ repo }/milestones`);
+            const milestones = await github.paginate(`GET /repos/${ owner }/${ "methods" }/milestones`);
             console.log(milestones);

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -1,9 +1,8 @@
 name: sync milestones
 
 on:
-  push:
-    branches:
-      - 374-milestone-syncing
+  milestone:
+    types: [created]
 
 jobs:
   synchronize:
@@ -22,16 +21,20 @@ jobs:
           installation_id: ${{ secrets.PROJECT_INSTALLATION_ID }}
           private_key: ${{ secrets.PROJECT_PRIVATE_KEY }}
       
-      - name: list milestones in this repo
+      - name: sync milestones
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
+            // Get the metadata about this repo from the workflow context
             const { owner, repo } = context.repo;
+            // And remove this repo from the list of repos to sync to. No need
+            // to sync myself with myself.
             const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
 
+            // Get a list of this repo's milestones
             const myMilestones = await github
-              .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+              .paginate(`GET /repos/${owner}/${repo}/milestones`)
               .then((milestones) =>
                 milestones.map(({ title, description, due_on, state }) => ({
                   title,
@@ -40,19 +43,24 @@ jobs:
                   state,
                 }))
               );
-            const milestoneNames = new Set(myMilestones.map(({ title }) => title));
 
+            // Now for each sync target repo...
             for await (const target of syncTargets) {
+              // Get the titles of their milestones, which we'll use to filter
+              // down to which milestones to synchronize
               const theirMilestones = new Set(
                 await github
-                  .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+                  .paginate(`GET /repos/${owner}/${target}/milestones`)
                   .then((milestones) => milestones.map(({ title }) => title))
               );
 
               for await (const milestone of myMilestones) {
+                // If a milestone with this title does NOT exist in the target
+                // repo, then we should create one.
                 if (!theirMilestones.has(milestone.title)) {
-                  // create this milestone over there
-                  console.log(`add milestone ${milestone.title} to ${target}`);
+                  // Expand the milestone so we push the title, description, due
+                  // date, and status (open/closed) all at once.
+                  await github.rest.issues.createMilestone({ owner, repo: target, ...milestone });
                 }
               }
             }

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -28,5 +28,32 @@ jobs:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const milestones = await github.paginate(`GET /repos/${ owner }/${ "methods" }/milestones`);
-            console.log(milestones);
+            const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
+
+            const myMilestones = await github
+              .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+              .then((milestones) =>
+                milestones.map(({ title, description, due_on, state }) => ({
+                  title,
+                  description,
+                  due_on,
+                  state,
+                }))
+              );
+            const milestoneNames = new Set(myMilestones.map(({ title }) => title));
+
+            for await (const target of syncTargets) {
+              const theirMilestones = new Set(
+                await github
+                  .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+                  .then((milestones) => milestones.map(({ title }) => title))
+              );
+
+              for await (const milestone of myMilestones) {
+                if (!theirMilestones.has(milestone.title)) {
+                  // create this milestone over there
+                  console.log(`add milestone ${milestone.title} to ${target}`);
+                }
+              }
+            }
+

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -1,0 +1,32 @@
+name: sync milestones
+
+on:
+  push:
+    branches:
+      - 374-milestone-syncing
+
+jobs:
+  synchronize:
+    name: synchronize milestones
+    runs-on: ubuntu-latest
+
+    steps:
+      # Rather than use a personal access token to interact with the project, we
+      # can use this GitHub App. There's an API for exchanging app credentials
+      # for a short-term token, and we use that API here.
+      - name: get token
+        uses: tibdex/github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.PROJECT_APP_ID }}
+          installation_id: ${{ secrets.PROJECT_INSTALLATION_ID }}
+          private_key: ${{ secrets.PROJECT_PRIVATE_KEY }}
+      
+      - name: list milestones in this repo
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const milestones = github.paginate(`GET /repos/${ owner }/${ repo }/milestones`);
+            console.log(milestones);

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -28,5 +28,5 @@ jobs:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const milestones = github.paginate(`GET /repos/${ owner }/${ repo }/milestones`);
+            const milestones = await github.paginate(`GET /repos/${ owner }/${ repo }/milestones`);
             console.log(milestones);


### PR DESCRIPTION
## Description of changes

Adds an automation to sync creation of milestones. When a milestone is created in this repo, the same milestone is also created in the [ux-guide](/18F/ux-guide) repo.

- Addresses 18F/ux-guide#374
## Known issues

- does not update milestones if they are *changed*

## Related issues

- closes #374

## Reviewers:

- [x] @cannandev: Please review the GitHub Actions code. It is identical to 18F/methods#653
- [x] @MelissaBraxton and/or @bpdesigns: Please review the behavior describe above to make sure it's right.