### PR TITLE
Fix link to Spanish consent form example

### DIFF
--- a/_pages/resources/participant-agreement.md
+++ b/_pages/resources/participant-agreement.md
@@ -10,8 +10,7 @@ English version:
 - [Google Docs version with participant compensation](https://docs.google.com/document/d/18GLTggHUDI5MVrmL5Lbot58EB6c6tAkMbg54GqFaETc/edit)
 - [Google Docs version without participant compensation](https://docs.google.com/document/d/1EPElAVthOF2ojcoamRitDHSYK4lT9c5yFY8IBwbJNqE/edit)
 
-[Spanish version]({{ site.baseurl }}/participant-agreement-spanish-no-compensation) (Note: Updates of the Spanish version pending translation of the updated English version.)
-
+[Spanish version]({{ site.baseurl }}/participant-agreement-spanish) 
 ---
 
 This agreement relates to your participation in a U.S. General Services Administration (GSA) design research project. The project will take place between `<project start date>` and `<project end date>`. Our session with you is scheduled for `<session duration>`. The project’s purpose is to better understand `<area of inquiry>`. We ask that you read, sign, and return this agreement so you know your rights and what to expect from us. 

--- a/_pages/resources/participant-agreement.md
+++ b/_pages/resources/participant-agreement.md
@@ -11,6 +11,7 @@ English version:
 - [Google Docs version without participant compensation](https://docs.google.com/document/d/1EPElAVthOF2ojcoamRitDHSYK4lT9c5yFY8IBwbJNqE/edit)
 
 [Spanish version]({{ site.baseurl }}/participant-agreement-spanish) 
+
 ---
 
 This agreement relates to your participation in a U.S. General Services Administration (GSA) design research project. The project will take place between `<project start date>` and `<project end date>`. Our session with you is scheduled for `<session duration>`. The project’s purpose is to better understand `<area of inquiry>`. We ask that you read, sign, and return this agreement so you know your rights and what to expect from us. 


### PR DESCRIPTION
## Description of changes

This PR fixes a broken link to the Spanish language version of the consent form. It also removes language about updates to the Spanish form as pending, since  we recently published the updated Spanish language version of the form. 


## Reviewers:

- [ ] @bpdesigns 
- [ ] @geekygirlsarah 

